### PR TITLE
Update for Reachability 4.0 CocoaPods framework name change

### DIFF
--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -13,7 +13,7 @@ import CocoaLumberjack
 import Alamofire
 import SwiftyJSON
 import Mapbox
-import ReachabilitySwift
+import Reachability
 
 class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, SceneLocationViewDelegate {
     let sceneLocationView = SceneLocationView()


### PR DESCRIPTION
Reachability is changing CocoaPods framework name past 4.0, to 'Reachability' from 'ReachabilitySwift'