### PR TITLE
Align the CocoaPods app target

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@
   verification.
 - Removed the empty `ReadMe.md` case-variant that overwrote the maintained
   `README.md` on default case-insensitive macOS filesystems.
+- Aligned the Podfile with the checked-in `FoursquareARCamera` native target
+  without changing the legacy dependency lockfile.
 
 ## 2026-06-10
 

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '11.0'
 use_frameworks!
 
-target 'PlacesARCamera' do
+target 'FoursquareARCamera' do
 	pod 'CocoaLumberjack/Swift', :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack', :branch => 'master'
 	pod 'AlamofireSwiftyJSON'
 	pod 'Mapbox-iOS-SDK'

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 ## Running or Using the Project
 
 - Open `FoursquareARCamera.xcworkspace` in Xcode after `pod install`, choose the app or sample scheme, and run it on a physical device for AR/camera/location behavior.
+- The Podfile targets the checked-in `FoursquareARCamera` native target. The
+  legacy `Podfile.lock` remains unchanged until dependencies are intentionally
+  resolved with a compatible CocoaPods/Xcode toolchain.
 - Configure `MAPBOX_ACCESS_TOKEN`, `FOURSQUARE_CLIENT_ID`, and `FOURSQUARE_CLIENT_SECRET` as local build settings, for example through an untracked `.xcconfig` file or Xcode scheme environment.
 
 This is a preserved Swift 4.0 and iOS 11-era sample, not a current production
@@ -169,6 +172,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   legacy SDK and dependency modernization sequence.
 - See `docs/plans/2026-06-12-hosted-project-validation.md` for the GitHub
   Actions and hosted Xcode project validation contract.
+- See `docs/plans/2026-06-12-cocoapods-target-alignment.md` for the native
+  target alignment and lockfile boundary.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,6 +61,8 @@ Legacy Swift, CocoaPods, Mapbox, ARKit, Core Location, or Foursquare API moderni
 should be reviewed as security- and privacy-sensitive integration work. Keep
 dependency changes reproducible, preserve attribution and permission checks,
 and verify camera/location behavior on a physical device before release.
+Keep the Podfile target aligned with the checked-in Xcode native target, and
+review any lockfile regeneration as an intentional dependency change.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -28,6 +28,8 @@ Current baseline:
 - `scripts/check-baseline.sh`, `make lint`, `make test`, `make build`, and
   `make check` verify credential placeholders, local artifact ignores,
   Info.plist XML, and workspace visibility.
+- The Podfile target, Xcode native target, and generated
+  `Pods-FoursquareARCamera` references use the same target name.
 - `MAPBOX_ACCESS_TOKEN`, `FOURSQUARE_CLIENT_ID`, and
   `FOURSQUARE_CLIENT_SECRET` are local build settings.
 - detailed location logs are avoided in the venue lookup and scene-location
@@ -82,6 +84,7 @@ Next priorities:
   dedicated pass
 - Pin CocoaPods dependencies before changing Swift, Mapbox, ARKit/Core
   Location, or Foursquare API behavior
+- Regenerate `Podfile.lock` only in a dedicated compatible CocoaPods/Xcode pass
 - Add safer error handling for API failures and missing credentials
 
 Contribution rules:

--- a/docs/plans/2026-06-12-cocoapods-target-alignment.md
+++ b/docs/plans/2026-06-12-cocoapods-target-alignment.md
@@ -1,0 +1,44 @@
+---
+title: CocoaPods Target Alignment
+date: 2026-06-12
+status: planned
+execution: build-configuration
+---
+
+## Context
+
+The checked-in Xcode project has one native app target named
+`FoursquareARCamera`, and its generated CocoaPods support references are named
+`Pods-FoursquareARCamera`. The Podfile instead declares `PlacesARCamera`, which
+does not exist in the project, so `pod install` cannot integrate dependencies
+with the app target described by the repository.
+
+## Goals
+
+- Align the Podfile target with the checked-in Xcode native target.
+- Guard against reintroducing the stale `PlacesARCamera` name.
+- Keep the existing Swift 4.0, iOS 11, pod declarations, lockfile, and generated
+  project references unchanged in this focused repair.
+- Document that dependency resolution and lockfile regeneration still require a
+  dedicated legacy CocoaPods/Xcode modernization pass.
+
+## Implementation
+
+- Change the Podfile target to `FoursquareARCamera`.
+- Extend `scripts/check-baseline.sh` to require one matching Podfile target,
+  reject `PlacesARCamera`, and verify the project/native CocoaPods references.
+- Update README, VISION, SECURITY, and CHANGES with the target-alignment and
+  lockfile boundary.
+
+## Verification
+
+- `sh -n scripts/check-baseline.sh`
+- `make lint`
+- `make test`
+- `make build`
+- `make check`
+- `git diff --check`
+- Hosted macOS `xcodebuild -list` project parsing
+
+`pod install` is intentionally not claimed here because CocoaPods and the
+legacy dependency toolchain are unavailable in this environment.

--- a/docs/plans/2026-06-12-cocoapods-target-alignment.md
+++ b/docs/plans/2026-06-12-cocoapods-target-alignment.md
@@ -1,7 +1,7 @@
 ---
 title: CocoaPods Target Alignment
 date: 2026-06-12
-status: planned
+status: completed
 execution: build-configuration
 ---
 

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -16,6 +16,7 @@ VENUE_LOOKUP_RETRY_PLAN="$ROOT_DIR/docs/plans/2026-06-09-foursquare-venue-lookup
 VENUE_COORDINATE_PLAN="$ROOT_DIR/docs/plans/2026-06-10-foursquare-venue-coordinate-validation.md"
 LEGACY_SDK_PLAN="$ROOT_DIR/docs/plans/2026-06-10-legacy-sdk-modernization-boundary.md"
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-12-hosted-project-validation.md"
+POD_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cocoapods-target-alignment.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -49,6 +50,7 @@ for path in \
   "docs/plans/2026-06-10-foursquare-venue-coordinate-validation.md" \
   "docs/plans/2026-06-10-legacy-sdk-modernization-boundary.md" \
   "docs/plans/2026-06-12-hosted-project-validation.md" \
+  "docs/plans/2026-06-12-cocoapods-target-alignment.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
   "docs/plans/2026-06-09-location-authorization-start-guard.md" \
   "docs/plans/2026-06-09-info-label-text-guard.md" \
@@ -64,6 +66,18 @@ makefile="$ROOT_DIR/Makefile"
 if ! grep -Eq '^\.PHONY: .*build.*check.*lint.*test|^\.PHONY: .*build.*lint.*test.*check' "$makefile" ||
   ! grep -Fq "lint test build: check" "$makefile"; then
   printf '%s\n' "Makefile must expose lint, test, build, and check gate targets." >&2
+  exit 1
+fi
+
+pod_target_count=$(grep -Ec "^[[:space:]]*target 'FoursquareARCamera' do[[:space:]]*$" "$ROOT_DIR/Podfile" || true)
+project_target_count=$(grep -Fc 'name = FoursquareARCamera;' "$ROOT_DIR/FoursquareARCamera.xcodeproj/project.pbxproj" || true)
+
+if [ "$pod_target_count" -ne 1 ] ||
+  [ "$project_target_count" -ne 1 ] ||
+  grep -Fq "target 'PlacesARCamera'" "$ROOT_DIR/Podfile" ||
+  ! grep -Fq "Pods-FoursquareARCamera.debug.xcconfig" "$ROOT_DIR/FoursquareARCamera.xcodeproj/project.pbxproj" ||
+  ! grep -Fq "Pods-FoursquareARCamera.release.xcconfig" "$ROOT_DIR/FoursquareARCamera.xcodeproj/project.pbxproj"; then
+  printf '%s\n' "Podfile and generated CocoaPods references must align with the FoursquareARCamera native target." >&2
   exit 1
 fi
 
@@ -524,6 +538,12 @@ if ! grep -Fq "status: completed" "$CI_PLAN" ||
   ! grep -Fq "macos-15" "$CI_PLAN" ||
   ! grep -Fq "persisted checkout credentials" "$CI_PLAN"; then
   printf '%s\n' "Hosted project validation plan must record the completed security and verification contract." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$POD_TARGET_PLAN" ||
+  ! grep -Fq "make check" "$POD_TARGET_PLAN"; then
+  printf '%s\n' "CocoaPods target alignment plan must be completed and record verification." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- change the Podfile target from nonexistent `PlacesARCamera` to the checked-in `FoursquareARCamera` native target
- enforce consistency across the Podfile, native target, and generated `Pods-FoursquareARCamera` references
- document that lockfile regeneration and Reachability dependency reconciliation remain a dedicated legacy toolchain pass

## Verification

- `sh -n scripts/check-baseline.sh`
- `make lint`
- `make test`
- `make build`
- `make check`
- `git diff --check`
- confirmed `Podfile.lock` has no diff
- intentional stale-target mutation rejected

CocoaPods and local Xcode are unavailable in this environment, so this PR does not claim `pod install`, app compilation, signing, simulator, camera, AR, Mapbox, or Foursquare integration coverage.
