### PR TITLE
docs: enforce CocoaPods target verification evidence

### DIFF
--- a/docs/plans/2026-06-12-cocoapods-target-alignment.md
+++ b/docs/plans/2026-06-12-cocoapods-target-alignment.md
@@ -42,3 +42,21 @@ with the app target described by the repository.
 
 `pod install` is intentionally not claimed here because CocoaPods and the
 legacy dependency toolchain are unavailable in this environment.
+
+## Work Completed
+
+- Aligned the Podfile with the checked-in `FoursquareARCamera` native target.
+- Added source contracts for the single Podfile target, project target, and
+  generated `Pods-FoursquareARCamera` support references.
+- Preserved the legacy pod declarations, lockfile, Swift, deployment, and
+  generated project settings outside the target-name repair.
+
+## Verification Completed
+
+- All four Make gates, shell syntax, and `git diff --check` passed locally;
+  Xcode project listing was truthfully skipped because Xcode is unavailable.
+- Implementation push run `27392510844` and pull-request run `27392514499`
+  passed at commit `8c7f86f1e375cc3208925b2e4cdd2bf8c2600413`, including hosted
+  `xcodebuild -list`.
+- Post-merge push run `27392528885` and CodeQL run `27402320459` passed at
+  default-branch merge commit `51938faf4329223b48bcf1583ab652c7f05a0f42`.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -541,10 +541,31 @@ if ! grep -Fq "status: completed" "$CI_PLAN" ||
   exit 1
 fi
 
-if ! grep -Fq "status: completed" "$POD_TARGET_PLAN" ||
-  ! grep -Fq "make check" "$POD_TARGET_PLAN"; then
-  printf '%s\n' "CocoaPods target alignment plan must be completed and record verification." >&2
-  exit 1
-fi
+python3 - "$POD_TARGET_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "All four Make gates",
+    "push run `27392510844`",
+    "pull-request run `27392514499`",
+    "push run `27392528885`",
+    "CodeQL run `27402320459`",
+)
+
+if (
+    statuses != ["status: completed"]
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "CocoaPods target alignment plan must remain completed with actual verification recorded."
+    )
+PY
 
 printf '%s\n' "foursquare-ar-camera-ios credential baseline checks passed."


### PR DESCRIPTION
## Summary

The CocoaPods target-alignment repair now has a fail-closed verification
record. The plan separates intended commands from completed local and hosted
evidence, and the baseline rejects stale completion or pending run claims.

## Baseline

The pre-change constraints and motivation are captured in the Summary and existing supporting sections.

## Improvements
- Record all four local Make gates and the Xcode-unavailable boundary.
- Record exact implementation push/pull-request and post-merge push/CodeQL
  results, including hosted `xcodebuild -list`.
- Parse the plan frontmatter and completed-verification section instead of
  accepting checklist text as proof.
- Reject pending/TODO markers even when historical success IDs remain present.

## Validation

- `make check`, `make lint`, `make test`, and `make build`.
- `sh -n scripts/check-baseline.sh` and `git diff --check`.
- Hostile mutations rejected stale completed status, pending evidence with an
  old run ID, the stale `PlacesARCamera` target, and a duplicate Podfile target.

## Risk

- This follow-up changes only plan evidence and its static contract; Podfile,
  Xcode project, lockfile, and dependency declarations are unchanged.
- `pod install` remains intentionally unclaimed for the legacy dependency
  toolchain.
- Secret-scanning alert #1 remains open for a historical Mapbox token in `FoursquareARCamera/Info.plist` at commit `4aa9566d4d9ad44315e6903462979e311c3e3f15`; current-tree guards do not prove provider-side revocation, so only the credential owner should resolve the alert.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)

## Follow-Ups

No additional follow-up is introduced by this description-only normalization; existing monitoring and remaining-work notes remain authoritative.