### PR TITLE
Pin CocoaLumberjack to the locked commit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-13
+
+- Replaced the mutable CocoaLumberjack `master` selector with the exact Swift 4
+  commit already recorded in `Podfile.lock`.
+- Aligned lockfile source metadata without changing resolved pod versions and
+  documented the remaining legacy Podfile-checksum regeneration requirement.
+
 ## 2026-06-12
 
 - Added a bounded, least-privilege macOS GitHub Actions workflow that runs the

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ platform :ios, '11.0'
 use_frameworks!
 
 target 'FoursquareARCamera' do
-	pod 'CocoaLumberjack/Swift', :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack', :branch => 'master'
+	pod 'CocoaLumberjack/Swift', :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack', :commit => 'f4294a13470d43260569d62aac6e1009fbef491a'
 	pod 'AlamofireSwiftyJSON'
 	pod 'Mapbox-iOS-SDK'
 	pod 'ReachabilitySwift'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,12 +11,12 @@ PODS:
 
 DEPENDENCIES:
   - AlamofireSwiftyJSON
-  - CocoaLumberjack/Swift (from `https://github.com/CocoaLumberjack/CocoaLumberjack`, branch `master`)
+  - CocoaLumberjack/Swift (from `https://github.com/CocoaLumberjack/CocoaLumberjack`, commit `f4294a13470d43260569d62aac6e1009fbef491a`)
   - Mapbox-iOS-SDK
 
 EXTERNAL SOURCES:
   CocoaLumberjack:
-    :branch: master
+    :commit: f4294a13470d43260569d62aac6e1009fbef491a
     :git: https://github.com/CocoaLumberjack/CocoaLumberjack
 
 CHECKOUT OPTIONS:

--- a/README.md
+++ b/README.md
@@ -51,17 +51,20 @@ The setup commands above are derived from repository files. Legacy mobile, Pytho
 
 - Open `FoursquareARCamera.xcworkspace` in Xcode after `pod install`, choose the app or sample scheme, and run it on a physical device for AR/camera/location behavior.
 - The Podfile targets the checked-in `FoursquareARCamera` native target. The
-  legacy `Podfile.lock` remains unchanged until dependencies are intentionally
-  resolved with a compatible CocoaPods/Xcode toolchain.
+  CocoaLumberjack source selector is pinned to the exact Swift 4 commit already
+  recorded by `Podfile.lock`.
 - Configure `MAPBOX_ACCESS_TOKEN`, `FOURSQUARE_CLIENT_ID`, and `FOURSQUARE_CLIENT_SECRET` as local build settings, for example through an untracked `.xcconfig` file or Xcode scheme environment.
 
 This is a preserved Swift 4.0 and iOS 11-era sample, not a current production
-SDK baseline. The CocoaPods graph includes legacy dependencies, including a
-CocoaLumberjack master branch reference, and the checked-in Mapbox, ARKit/Core
+SDK baseline. The CocoaPods graph includes legacy dependencies, but
+CocoaLumberjack no longer resolves a mutable branch: it uses commit
+`f4294a13470d43260569d62aac6e1009fbef491a`. The checked-in Mapbox, ARKit/Core
 Location, and Foursquare venue integration should be modernized in isolated,
 device-verified changes rather than through an unreviewed bulk update.
 The current lockfile records CocoaPods 1.3.1; any regenerated lockfile should
 document the replacement CocoaPods version and dependency review.
+The checked-in `PODFILE CHECKSUM` predates the commit-selector update and must
+be regenerated with the legacy toolchain before claiming a fresh install.
 `make check` parses the checked-in Xcode project when Xcode is available. Use
 the workspace for functional builds only after generating Pods locally.
 
@@ -174,6 +177,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   Actions and hosted Xcode project validation contract.
 - See `docs/plans/2026-06-12-cocoapods-target-alignment.md` for the native
   target alignment and lockfile boundary.
+- See `docs/plans/2026-06-13-cocoalumberjack-commit-pin.md` for the immutable
+  CocoaLumberjack source boundary and Podfile-checksum limitation.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,10 @@ dependency changes reproducible, preserve attribution and permission checks,
 and verify camera/location behavior on a physical device before release.
 Keep the Podfile target aligned with the checked-in Xcode native target, and
 review any lockfile regeneration as an intentional dependency change.
+The CocoaLumberjack Git source is pinned to the exact Swift 4 commit already
+recorded by the lockfile; do not restore a mutable branch selector. The legacy
+Podfile checksum still requires CocoaPods 1.3.1 regeneration before dependency
+installation can be claimed current.
 
 ## Dependency and Supply Chain Security
 

--- a/VISION.md
+++ b/VISION.md
@@ -61,10 +61,14 @@ Current baseline:
 - `.DS_Store` and `mapbox_access_token` are ignored and not tracked.
 - Swift 4.0 and iOS 11 remain the checked-in legacy compiler and deployment
   boundary; this repository does not claim a current production SDK baseline.
+- CocoaLumberjack source resolution is pinned to the existing reviewed Swift 4
+  commit while the remaining legacy pod graph stays unchanged.
 
 Next priorities:
 
 - Verify AR, camera, location, Mapbox, and Foursquare behavior on a physical device
+- Regenerate the Podfile checksum with CocoaPods 1.3.1 before claiming a fresh
+  dependency installation
 - Add tests or manual checklists for missing credentials and API failure states
 - Keep venue tap handling resilient when SceneKit node shapes change
 - Keep debug overlays resilient when AR position, heading, and time values

--- a/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md
+++ b/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md
@@ -1,0 +1,75 @@
+---
+title: CocoaLumberjack Commit Pin
+type: security
+status: in_progress
+date: 2026-06-13
+---
+
+# CocoaLumberjack Commit Pin
+
+## Summary
+
+Replace the mutable CocoaLumberjack `master` source selector with the exact
+Swift 4 commit already recorded in the checked-in lockfile.
+
+## Priority
+
+1. Remove mutable dependency source resolution from the Podfile.
+2. Keep Podfile and lockfile source metadata aligned to one reviewed commit.
+3. Preserve the existing legacy pod graph and toolchain limitations.
+
+## Requirements
+
+- R1. The CocoaLumberjack Podfile declaration must use commit
+  `f4294a13470d43260569d62aac6e1009fbef491a` and no branch selector.
+- R2. The lockfile dependency and external-source entries must record the same
+  commit, with no `master` branch metadata.
+- R3. The existing checkout option must remain at the same exact commit.
+- R4. Alamofire, AlamofireSwiftyJSON, Mapbox, SwiftyJSON, CocoaLumberjack 3.2.1,
+  spec checksums, and CocoaPods 1.3.1 metadata must remain unchanged.
+- R5. Static contracts must reject branch selectors, commit drift, duplicate
+  commit selectors, and lockfile graph drift.
+- R6. Documentation must state that the pin removes moving-branch resolution
+  but does not modernize or authenticate the legacy dependency graph.
+- R7. The Podfile checksum limitation must be explicit because CocoaPods 1.3.1
+  regeneration is unavailable on this host.
+
+## Non-Goals
+
+- Running `pod install`, regenerating the workspace, or claiming dependency
+  installation without an era-compatible CocoaPods/Xcode environment.
+- Upgrading CocoaLumberjack, Mapbox, Alamofire, SwiftyJSON, iOS, or Swift.
+- Resolving the historical Mapbox secret-scanning alert or rewriting history.
+- Changing AR, camera, location, venue lookup, logging, or UI behavior.
+
+## Implementation Units
+
+### 1. Pod Source Pin
+
+Files: `Podfile`, `Podfile.lock`
+
+- Replace the branch selector with the exact existing checkout commit.
+- Align dependency and external-source metadata without changing resolved pods.
+
+### 2. Static Contracts
+
+Files: `scripts/check-baseline.sh`
+
+- Require three aligned commit references and zero mutable branch selectors.
+- Preserve exact pod versions, checksums, CocoaPods version, and checksum caveat.
+
+### 3. Repository Guidance
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
+
+- Record the reproducibility improvement and remaining legacy limitations.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build`.
+- Reintroduce `master`, drift one lockfile commit, and change a resolved pod
+  version; the static gate must reject each mutation.
+- Run shell syntax, plist/workspace parsing, `git diff --check`, and intended-file
+  secret scans.
+- Take one bounded exact-head pull-request and CodeQL snapshot after push; do
+  not poll.

--- a/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md
+++ b/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md
@@ -1,7 +1,7 @@
 ---
 title: CocoaLumberjack Commit Pin
 type: security
-status: in_progress
+status: completed
 date: 2026-06-13
 ---
 
@@ -73,3 +73,24 @@ Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`
   secret scans.
 - Take one bounded exact-head pull-request and CodeQL snapshot after push; do
   not poll.
+
+## Work Completed
+
+- Replaced the CocoaLumberjack `master` selector with commit
+  `f4294a13470d43260569d62aac6e1009fbef491a` in the Podfile.
+- Aligned the dependency and external-source lockfile metadata to the same
+  commit while preserving the resolved versions, spec checksums, checkout
+  option, Podfile checksum, and CocoaPods 1.3.1 record.
+- Added static source, graph, documentation, and completed-plan contracts.
+- Documented that the historical Podfile checksum requires regeneration with
+  CocoaPods 1.3.1 before claiming a fresh dependency installation.
+
+## Verification Completed
+
+- A pristine copied tree passed `make check` with the completed-plan evidence
+  supplied in the copy.
+- The branch mutation failed after restoring `:branch => 'master'`.
+- The commit drift mutation failed after changing the external-source commit.
+- The resolved graph mutation failed after changing Mapbox 3.6.4 to 3.6.5.
+- The hosted pull-request check is a post-push evidence step; its bounded
+  exact-head result is recorded after the implementation commit is pushed.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -17,6 +17,7 @@ VENUE_COORDINATE_PLAN="$ROOT_DIR/docs/plans/2026-06-10-foursquare-venue-coordina
 LEGACY_SDK_PLAN="$ROOT_DIR/docs/plans/2026-06-10-legacy-sdk-modernization-boundary.md"
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-12-hosted-project-validation.md"
 POD_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cocoapods-target-alignment.md"
+COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -51,6 +52,7 @@ for path in \
   "docs/plans/2026-06-10-legacy-sdk-modernization-boundary.md" \
   "docs/plans/2026-06-12-hosted-project-validation.md" \
   "docs/plans/2026-06-12-cocoapods-target-alignment.md" \
+  "docs/plans/2026-06-13-cocoalumberjack-commit-pin.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
   "docs/plans/2026-06-09-location-authorization-start-guard.md" \
   "docs/plans/2026-06-09-info-label-text-guard.md" \
@@ -328,15 +330,51 @@ if ! grep -Fq "Foursquare venue lookup retries should stay bounded" "$ROOT_DIR/S
 fi
 
 if ! grep -Fq "Swift 4.0 and iOS 11" "$ROOT_DIR/README.md" ||
-  ! grep -Fq "CocoaLumberjack master branch" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "CocoaLumberjack no longer resolves a mutable branch" "$ROOT_DIR/README.md" ||
   ! grep -Fq "legacy-sdk-modernization-boundary" "$ROOT_DIR/README.md"; then
   printf '%s\n' "README must document the legacy SDK and dependency boundary." >&2
   exit 1
 fi
 
-if ! grep -Fq ":branch => 'master'" "$ROOT_DIR/Podfile" ||
-  ! grep -Fq "COCOAPODS: 1.3.1" "$ROOT_DIR/Podfile.lock"; then
-  printf '%s\n' "Legacy modernization boundary must track the mutable pod source and lockfile tool version." >&2
+python3 - "$ROOT_DIR/Podfile" "$ROOT_DIR/Podfile.lock" <<'PY'
+import sys
+from pathlib import Path
+
+podfile = Path(sys.argv[1]).read_text()
+lockfile = Path(sys.argv[2]).read_text()
+commit = "f4294a13470d43260569d62aac6e1009fbef491a"
+
+if podfile.count(":commit => '{}'".format(commit)) != 1:
+    raise SystemExit("Podfile must contain one exact CocoaLumberjack commit selector.")
+if ":branch" in podfile or "branch `master`" in lockfile or ":branch:" in lockfile:
+    raise SystemExit("CocoaLumberjack dependency metadata must not use a mutable branch selector.")
+if lockfile.count(commit) != 3:
+    raise SystemExit("Podfile.lock must align dependency, external source, and checkout metadata to one commit.")
+
+required_lock_contracts = (
+    "- Alamofire (4.5.1)",
+    "- AlamofireSwiftyJSON (1.0.0):",
+    "- CocoaLumberjack/Default (3.2.1)",
+    "- CocoaLumberjack/Swift (3.2.1):",
+    "- Mapbox-iOS-SDK (3.6.4)",
+    "- SwiftyJSON (3.1.4)",
+    "Alamofire: 2d95912bf4c34f164fdfc335872e8c312acaea4a",
+    "AlamofireSwiftyJSON: 78908b766483a28aa5cc90fd191a687467042973",
+    "CocoaLumberjack: 520616f8e72226ca2c729b43981b66bc483745ce",
+    "Mapbox-iOS-SDK: 47847dd44285477e0dfffd0130f65c8a52823ada",
+    "SwiftyJSON: c2842d878f95482ffceec5709abc3d05680c0220",
+    "PODFILE CHECKSUM: de49009947665df59c3e8399b35c779a2ab5c3f2",
+    "COCOAPODS: 1.3.1",
+)
+if any(lockfile.count(item) != 1 for item in required_lock_contracts):
+    raise SystemExit("Legacy resolved pod versions, checksums, and CocoaPods metadata must not drift.")
+PY
+
+if ! grep -Fq "PODFILE CHECKSUM" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "requires CocoaPods 1.3.1 regeneration" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Regenerate the Podfile checksum with CocoaPods 1.3.1" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "mutable CocoaLumberjack \`master\` selector" "$ROOT_DIR/CHANGES.md"; then
+  printf '%s\n' "Repository guidance must document the immutable pod source and checksum limitation." >&2
   exit 1
 fi
 
@@ -565,6 +603,33 @@ if (
 ):
     raise SystemExit(
         "CocoaPods target alignment plan must remain completed with actual verification recorded."
+    )
+PY
+
+python3 - "$COCOALUMBERJACK_PIN_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "branch mutation failed",
+    "commit drift mutation failed",
+    "resolved graph mutation failed",
+    "hosted pull-request check",
+)
+
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "CocoaLumberjack commit pin plan must remain completed with actual verification recorded."
     )
 PY
 


### PR DESCRIPTION
## Summary

- Replace the mutable CocoaLumberjack `master` selector with the exact commit already recorded in `Podfile.lock`.
- Align lockfile source metadata while preserving resolved pod versions and checksums.

## Baseline

The checked-in dependency graph remains the authority: resolved pod versions and checksums are preserved, and the CocoaLumberjack selector must match the exact locked commit.

## Improvements

- Removes the mutable CocoaLumberjack branch selector.
- Aligns lockfile source metadata with the immutable commit pin.
- Adds static and hostile-mutation contracts.
- Documents the legacy Podfile checksum limitation.

## Validation

- `make check`
- `make lint`
- `make test`
- `make build`
- `sh -n scripts/check-baseline.sh`
- Plist and workspace XML parsing
- Hostile branch, commit-drift, and resolved-graph mutations rejected
- Intended-file secret-pattern scan

## Risk

CocoaPods and Xcode are unavailable on this host. The checked-in `PODFILE CHECKSUM` remains the historical CocoaPods 1.3.1 value and is explicitly documented as requiring era-compatible regeneration before claiming a fresh dependency install.

## Follow-Ups

This pull request is stacked on #8. Use an era-compatible CocoaPods environment to regenerate and verify the Podfile checksum before claiming a fresh dependency installation.
