### PR TITLE
Validate Foursquare response status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@
 - Keep location manager setup and heading forwarding resilient when optional Core Location state is unavailable.
 - Reject non-finite or out-of-range venue coordinates, and reject non-finite or negative distances, before creating AR nodes or map annotations.
 - Keep credential, request, malformed-response, and empty-response retries bounded by the documented cooldown.
+- Require a 2xx Foursquare response status before JSON parsing, and keep
+  rejected responses on the generic no-body-log retry path.
 - Treat Swift, CocoaPods, Mapbox, ARKit/Core Location, and Foursquare API modernization as staged, device-verified work; update `Podfile.lock` only with an intentional dependency and CocoaPods toolchain review.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+- Required a 2xx Foursquare venue response before JSON parsing and routed
+  rejected statuses through the existing generic bounded retry path.
+- Added a scoped static contract for request count, status range, ordering, and
+  failure handling.
 - Replaced the mutable CocoaLumberjack `master` selector with the exact Swift 4
   commit already recorded in `Podfile.lock`.
 - Aligned lockfile source metadata without changing resolved pod versions and

--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -193,7 +193,9 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
             ]
             
             // Send HTTP request
-            Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters).responseJSON { response in
+            Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)
+                .validate(statusCode: 200..<300)
+                .responseJSON { response in
                 switch response.result {
                 case .success(let value):
                     let json = JSON(value)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ card subviews are added. Map annotation updates avoid force-unwrapping optional
 annotations while tracking the user and debug location estimate.
 Foursquare venue lookup retries use a bounded cooldown when credentials are
 missing, requests fail, or successful responses contain no valid venue payloads.
+Venue lookups validate a 2xx HTTP status before JSON response parsing; rejected
+statuses use the same generic bounded retry path without logging response data.
 Venue responses also require finite latitude/longitude within geographic bounds
 and a finite nonnegative distance before rendering.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,9 @@ while displaying user or debug location markers.
 Foursquare venue lookup retries should stay bounded so missing credentials,
 failed requests, or empty/malformed responses do not create immediate request
 loops while location updates continue.
+Foursquare venue responses should require a 2xx HTTP status before JSON parsing;
+rejected responses must use the generic retry path without logging bodies,
+credentials, request URLs, or location details.
 Foursquare venue coordinates should be finite and geographically bounded, and
 distance values should be finite and nonnegative before AR or map rendering.
 

--- a/VISION.md
+++ b/VISION.md
@@ -51,6 +51,8 @@ Current baseline:
   alert path.
 - Foursquare venue lookup retries use a bounded cooldown when credentials are
   missing, requests fail, or successful responses contain no valid venues.
+- Foursquare venue responses require a 2xx HTTP status before JSON parsing;
+  rejected statuses use the existing generic bounded retry path.
 - Venue response coordinates and distances are finite and range-checked before
   AR nodes or map annotations are created.
 - The local Makefile exposes lint, test, build, and check targets for a stable
@@ -82,6 +84,7 @@ Next priorities:
   overlays
 - Preserve bounded Foursquare venue lookup retries when changing API failure
   handling
+- Preserve 2xx status validation ahead of Foursquare JSON response parsing
 - Keep local verification targets available even while full Xcode testing needs
   a macOS toolchain
 - Modernize Swift, dependencies, AR/location APIs, and project settings in a

--- a/docs/plans/2026-06-13-foursquare-response-status-validation.md
+++ b/docs/plans/2026-06-13-foursquare-response-status-validation.md
@@ -1,7 +1,7 @@
 ---
 title: Foursquare Response Status Validation
 type: security
-status: planned
+status: completed
 date: 2026-06-13
 ---
 
@@ -86,8 +86,33 @@ Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
 
 ## Work Completed
 
-Pending implementation.
+- Chained Alamofire's exact `200..<300` status validator between the existing
+  venue request and `responseJSON` handler.
+- Preserved the existing request parameters, JSON parsing, coordinate checks,
+  rendering, generic failure message, and bounded retry release.
+- Added a function-scoped static contract for one request, one exact validator,
+  validator-before-body ordering, and one generic failure retry.
+- Documented the response status boundary and continuing legacy platform and
+  live-service validation limits.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- The validator removal mutation failed with the one-request/validator/handler
+  contract error.
+- The status range mutation failed after widening the accepted range to
+  `200..<400`.
+- The validation ordering mutation failed after moving the validator below the
+  JSON response handler.
+- The duplicate request mutation failed after adding a second venue request.
+- The failure retry mutation failed after replacing the bounded retry release
+  with a warning-only branch.
+- `make check`, `make lint`, `make test`, and `make build` passed the maintained
+  static baseline; each correctly reported that local `xcodebuild` is
+  unavailable.
+- `sh -n scripts/check-baseline.sh`, Info.plist and workspace XML parsing,
+  executable-mode verification, and `git diff --check` passed.
+- Intended-path artifact and secret scans found no generated files or embedded
+  credentials.
+- The hosted pull-request check and code-scanning results are recorded against
+  the exact pushed head in the external engineering tracker. Embedding that SHA
+  here would create a new head without exact-head hosted evidence.

--- a/docs/plans/2026-06-13-foursquare-response-status-validation.md
+++ b/docs/plans/2026-06-13-foursquare-response-status-validation.md
@@ -1,0 +1,93 @@
+---
+title: Foursquare Response Status Validation
+type: security
+status: planned
+date: 2026-06-13
+---
+
+# Foursquare Response Status Validation
+
+## Summary
+
+Reject non-success Foursquare HTTP responses before parsing response JSON or
+creating AR venue state.
+
+## Priority
+
+1. Keep HTTP error responses out of the successful venue parsing path.
+2. Reuse the existing bounded retry release for rejected responses.
+3. Preserve the legacy Alamofire, Swift, API request, credential, and UI
+   boundaries.
+
+## Requirements
+
+- R1. The venue search request must validate status codes in `200..<300`
+  before `responseJSON` handles the body.
+- R2. Status validation must use the existing Alamofire 4 request chain and
+  must not add a second request or dependency.
+- R3. Rejected status codes must reach the existing generic failure branch and
+  bounded retry release without logging response bodies, URLs, credentials, or
+  location details.
+- R4. Successful venue parsing, coordinate validation, empty-result retry,
+  credential lookup, request parameters, and AR/map rendering must remain
+  unchanged.
+- R5. Static contracts must reject validator removal, a widened status range,
+  validation after `responseJSON`, duplicate requests, and weakened failure
+  handling.
+- R6. README, SECURITY, VISION, CHANGES, and AGENTS must describe the status
+  boundary without claiming runtime or live-service validation.
+
+## Non-Goals
+
+- Changing the Foursquare endpoint, API version, parameters, credentials,
+  attribution, response schema, retry delay, or request timeout behavior.
+- Upgrading Alamofire, SwiftyJSON, Swift, iOS, CocoaPods, Xcode, ARKit, Mapbox,
+  or other dependencies.
+- Adding response-body logging, detailed server errors, telemetry, or user
+  interface changes.
+- Claiming compilation, signing, simulator/device behavior, or live Foursquare
+  compatibility from this Linux environment.
+
+## Implementation Units
+
+### 1. Request Status Boundary
+
+Files: `FoursquareARCamera/ViewController.swift`
+
+- Insert the exact 2xx status validator between request construction and JSON
+  response handling.
+- Preserve the existing generic failure and bounded retry path.
+
+### 2. Static Contract
+
+Files: `scripts/check-baseline.sh`
+
+- Scope request-chain checks to `getFoursquareLocations`.
+- Require one venue request, one exact status validator, validator-before-body
+  ordering, and the retained generic failure retry.
+
+### 3. Repository Guidance
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
+
+- Record the non-2xx rejection boundary and the continuing platform/live
+  validation limitations.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build`.
+- Remove the validator, widen it to include redirects, move it after
+  `responseJSON`, duplicate the request, and remove the failure retry; the
+  static gate must reject each mutation.
+- Run shell syntax, plist/workspace parsing, executable-mode verification,
+  `git diff --check`, and intended-path secret and artifact scans.
+- Take bounded exact-head push, pull-request, and code-scanning snapshots after
+  push; do not start a polling or watch loop.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -18,6 +18,7 @@ LEGACY_SDK_PLAN="$ROOT_DIR/docs/plans/2026-06-10-legacy-sdk-modernization-bounda
 CI_PLAN="$ROOT_DIR/docs/plans/2026-06-12-hosted-project-validation.md"
 POD_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cocoapods-target-alignment.md"
 COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md"
+RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status-validation.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -132,6 +133,27 @@ if ! grep -Fq 'configuredValue("FoursquareClientID")' "$view" ||
   printf '%s\n' "ViewController must use local credentials and avoid detailed location logging." >&2
   exit 1
 fi
+
+python3 - "$view" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+lookup = source.split("func getFoursquareLocations", 1)[-1].split("\n    @objc", 1)[0]
+request = 'Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)'
+validator = ".validate(statusCode: 200..<300)"
+response = ".responseJSON { response in"
+failure = 'self.allowVenueLookupRetryAfterDelay(reason: "Foursquare venue lookup failed.")'
+contract = (request, validator, response)
+positions = [lookup.find(fragment) for fragment in contract]
+
+if any(lookup.count(fragment) != 1 for fragment in contract):
+    raise SystemExit("Foursquare venue lookup must keep one request, 2xx validator, and JSON response handler.")
+if -1 in positions or positions != sorted(positions) or len(set(positions)) != len(positions):
+    raise SystemExit("Foursquare 2xx status validation must run before JSON response handling.")
+if lookup.count("case .failure:") != 1 or lookup.count(failure) != 1:
+    raise SystemExit("Rejected Foursquare responses must retain the bounded generic failure retry.")
+PY
 
 if ! grep -Fq "venueLatitude.isFinite" "$view" ||
   ! grep -Fq "(-90.0...90.0).contains(venueLatitude)" "$view" ||
@@ -630,6 +652,35 @@ if (
 ):
     raise SystemExit(
         "CocoaLumberjack commit pin plan must remain completed with actual verification recorded."
+    )
+PY
+
+python3 - "$RESPONSE_STATUS_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "validator removal mutation failed",
+    "status range mutation failed",
+    "validation ordering mutation failed",
+    "duplicate request mutation failed",
+    "failure retry mutation failed",
+    "hosted pull-request check",
+)
+
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Foursquare response status plan must remain completed with actual verification recorded."
     )
 PY
 


### PR DESCRIPTION
## Summary

Reject non-2xx Foursquare venue responses before JSON parsing or AR state creation.

## Baseline

This PR is stacked on the CocoaLumberjack commit-pin branch and preserves the legacy Swift 4, iOS 11, Alamofire 4, CocoaPods, credential, request, and rendering boundaries.

## Improvements

- require Alamofire status validation for the exact 200..<300 range
- keep rejected responses on the existing generic bounded retry path
- add a function-scoped contract for request count, status range, validation ordering, and failure handling
- document the response boundary without claiming live service or device validation

## Validation

- make check, make lint, make test, and make build passed
- shell syntax, plist/workspace XML parsing, executable mode, and git diff checks passed
- five hostile mutations were rejected: validator removal, widened status range, reordered validation, duplicate request, and removed retry release
- xcodebuild is unavailable on the Linux host; hosted macOS validation remains required

## Risk

The change uses Alamofire 4.5.1’s existing status validator but was not compiled, signed, run on a simulator/device, or exercised against the live Foursquare service locally.

## Follow-Ups

Record exact-head push, pull-request, Xcode project parsing, and code-scanning evidence in the engineering tracker; do not merge this stacked PR before its base.