### PR TITLE
fix: validate Foursquare response media type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@
 - Keep credential, request, malformed-response, and empty-response retries bounded by the documented cooldown.
 - Require a 2xx Foursquare response status before JSON parsing, and keep
   rejected responses on the generic no-body-log retry path.
+- Require the exact JSON response media type after status validation and before
+  response handling.
 - Treat Swift, CocoaPods, Mapbox, ARKit/Core Location, and Foursquare API modernization as staged, device-verified work; update `Podfile.lock` only with an intentional dependency and CocoaPods toolchain review.
 
 ## Agent workflow

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## 2026-06-13
 
+- Required the exact application/json response media type before Foursquare
+  JSON response handling.
+- Added request-chain ordering, retry, documentation, and evidence contracts for
+  media validation.
 - Required a 2xx Foursquare venue response before JSON parsing and routed
   rejected statuses through the existing generic bounded retry path.
 - Added a scoped static contract for request count, status range, ordering, and

--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -195,6 +195,7 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
             // Send HTTP request
             Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)
                 .validate(statusCode: 200..<300)
+                .validate(contentType: ["application/json"])
                 .responseJSON { response in
                 switch response.result {
                 case .success(let value):

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ card subviews are added. Map annotation updates avoid force-unwrapping optional
 annotations while tracking the user and debug location estimate.
 Foursquare venue lookup retries use a bounded cooldown when credentials are
 missing, requests fail, or successful responses contain no valid venue payloads.
-Venue lookups validate a 2xx HTTP status before JSON response parsing; rejected
-statuses use the same generic bounded retry path without logging response data.
+Venue lookups validate a 2xx HTTP status and exact application/json response
+media type before JSON response parsing; rejected responses use the same
+generic bounded retry path without logging response data.
 Venue responses also require finite latitude/longitude within geographic bounds
 and a finite nonnegative distance before rendering.
 
@@ -173,6 +174,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   annotation optional-state guardrails.
 - See `docs/plans/2026-06-09-foursquare-venue-lookup-retry-guard.md` for venue
   lookup retry guardrails.
+- See `docs/plans/2026-06-13-foursquare-response-content-type-validation.md`
+  for the exact JSON response media boundary.
 - See `docs/plans/2026-06-10-legacy-sdk-modernization-boundary.md` for the
   legacy SDK and dependency modernization sequence.
 - See `docs/plans/2026-06-12-hosted-project-validation.md` for the GitHub

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,9 +48,10 @@ while displaying user or debug location markers.
 Foursquare venue lookup retries should stay bounded so missing credentials,
 failed requests, or empty/malformed responses do not create immediate request
 loops while location updates continue.
-Foursquare venue responses should require a 2xx HTTP status before JSON parsing;
-rejected responses must use the generic retry path without logging bodies,
-credentials, request URLs, or location details.
+Foursquare venue responses should require a 2xx HTTP status and exact
+`application/json` response media type before JSON parsing; rejected responses
+must use the generic retry path without logging bodies, credentials, request
+URLs, or location details.
 Foursquare venue coordinates should be finite and geographically bounded, and
 distance values should be finite and nonnegative before AR or map rendering.
 

--- a/VISION.md
+++ b/VISION.md
@@ -53,6 +53,8 @@ Current baseline:
   missing, requests fail, or successful responses contain no valid venues.
 - Foursquare venue responses require a 2xx HTTP status before JSON parsing;
   rejected statuses use the existing generic bounded retry path.
+- Successful venue responses require the exact JSON response media type before
+  response handling.
 - Venue response coordinates and distances are finite and range-checked before
   AR nodes or map annotations are created.
 - The local Makefile exposes lint, test, build, and check targets for a stable
@@ -85,6 +87,7 @@ Next priorities:
 - Preserve bounded Foursquare venue lookup retries when changing API failure
   handling
 - Preserve 2xx status validation ahead of Foursquare JSON response parsing
+- Preserve exact JSON response media type validation ahead of response handling
 - Keep local verification targets available even while full Xcode testing needs
   a macOS toolchain
 - Modernize Swift, dependencies, AR/location APIs, and project settings in a

--- a/docs/plans/2026-06-13-foursquare-response-content-type-validation.md
+++ b/docs/plans/2026-06-13-foursquare-response-content-type-validation.md
@@ -1,7 +1,7 @@
 ---
 title: Foursquare Response Content Type Validation
 type: security
-status: planned
+status: completed
 date: 2026-06-13
 ---
 
@@ -83,8 +83,27 @@ Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
 
 ## Work Completed
 
-Pending implementation.
+- Added the exact Alamofire `application/json` content-type validator between
+  the existing 2xx validator and single JSON response handler.
+- Preserved the generic failure retry so rejected status or media metadata does
+  not log response content or create immediate request loops.
+- Extended the static request-chain contract and repository guidance for exact
+  media validation and continuing platform/live-validation limits.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- All four Make gates passed the maintained static baseline.
+- The validator removal mutation failed the single-chain contract.
+- The media allowlist mutation failed the exact validator contract.
+- The validation ordering mutation failed after a valid status/media line swap.
+- The duplicate handler mutation failed the single-handler contract.
+- The failure retry mutation failed the bounded generic retry contract.
+- The plan evidence mutation failed the completed-evidence contract.
+- Shell syntax, plist/workspace XML parsing, executable-mode verification,
+  `git diff --check`, and intended-file secret and artifact scans are included
+  in final-tree verification.
+- `xcodebuild`, CocoaPods installation, signing, simulator/device execution,
+  camera, AR, location, Mapbox, and live Foursquare behavior are unavailable or
+  intentionally unclaimed on this Linux host.
+- The hosted pull-request check and code-scanning snapshot will be recorded
+  against the exact pushed head in the external engineering tracker.

--- a/docs/plans/2026-06-13-foursquare-response-content-type-validation.md
+++ b/docs/plans/2026-06-13-foursquare-response-content-type-validation.md
@@ -1,0 +1,90 @@
+---
+title: Foursquare Response Content Type Validation
+type: security
+status: planned
+date: 2026-06-13
+---
+
+# Foursquare Response Content Type Validation
+
+## Summary
+
+Require successful Foursquare venue responses to declare `application/json`
+before Alamofire invokes the JSON response handler.
+
+## Priority
+
+1. Reject successful non-JSON representations before venue parsing.
+2. Preserve the existing single-request, 2xx validation, and retry behavior.
+3. Keep the legacy Swift 4, Alamofire, CocoaPods, AR, location, and credential
+   boundaries unchanged.
+
+## Requirements
+
+- R1. The venue request chain must call
+  `.validate(contentType: ["application/json"])` exactly once.
+- R2. Content-type validation must run after the exact 2xx status validator and
+  before the single `responseJSON` handler.
+- R3. Missing or incompatible content types must reach the existing generic
+  failure retry path without logging response content.
+- R4. Static contracts must reject validator removal, widened media allowlists,
+  reordered validation, duplicate requests or handlers, weakened retry
+  behavior, documentation drift, or incomplete plan evidence.
+- R5. README, SECURITY, VISION, CHANGES, and AGENTS must describe the exact JSON
+  response boundary without claiming live API or device validation.
+- R6. The completed plan must record actual local, mutation, and hosted
+  verification evidence.
+
+## Non-Goals
+
+- Changing the Foursquare endpoint, parameters, credentials, API version, or
+  success status range.
+- Supporting vendor JSON, text/json, HTML, XML, or content sniffing.
+- Changing venue parsing, coordinate validation, AR rendering, map annotations,
+  retries, or logging.
+- Updating Swift, iOS, Alamofire, CocoaPods, Mapbox, or project metadata.
+- Claiming compilation, signing, simulator/device, camera, location, or live
+  Foursquare validation from this Linux host.
+
+## Implementation Units
+
+### 1. Alamofire Media Validator
+
+Files: `FoursquareARCamera/ViewController.swift`
+
+- Add the exact JSON content-type validator between status validation and the
+  response handler.
+
+### 2. Static Contracts
+
+Files: `scripts/check-baseline.sh`
+
+- Require one request, one status validator, one JSON media validator, one
+  response handler, exact ordering, the failure retry, documentation, and
+  completed evidence.
+
+### 3. Repository Guidance
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
+
+- Record the media-type boundary and continuing platform/live-validation
+  limits.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build`.
+- Remove the validator, widen the allowlist, move it after `responseJSON`,
+  duplicate the handler, remove failure retry, and regress plan evidence; each
+  mutation must be rejected.
+- Run shell syntax, plist/workspace XML parsing, executable-mode checks,
+  `git diff --check`, and intended-file secret/artifact scans.
+- Take bounded exact-head push, pull-request, and code-scanning snapshots after
+  push; do not start a watch loop.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -19,6 +19,7 @@ CI_PLAN="$ROOT_DIR/docs/plans/2026-06-12-hosted-project-validation.md"
 POD_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cocoapods-target-alignment.md"
 COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md"
 RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status-validation.md"
+RESPONSE_CONTENT_TYPE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-content-type-validation.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -54,6 +55,8 @@ for path in \
   "docs/plans/2026-06-12-hosted-project-validation.md" \
   "docs/plans/2026-06-12-cocoapods-target-alignment.md" \
   "docs/plans/2026-06-13-cocoalumberjack-commit-pin.md" \
+  "docs/plans/2026-06-13-foursquare-response-status-validation.md" \
+  "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
   "docs/plans/2026-06-09-location-authorization-start-guard.md" \
   "docs/plans/2026-06-09-info-label-text-guard.md" \
@@ -141,19 +144,31 @@ from pathlib import Path
 source = Path(sys.argv[1]).read_text()
 lookup = source.split("func getFoursquareLocations", 1)[-1].split("\n    @objc", 1)[0]
 request = 'Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)'
-validator = ".validate(statusCode: 200..<300)"
+status_validator = ".validate(statusCode: 200..<300)"
+content_type_validator = '.validate(contentType: ["application/json"])'
 response = ".responseJSON { response in"
 failure = 'self.allowVenueLookupRetryAfterDelay(reason: "Foursquare venue lookup failed.")'
-contract = (request, validator, response)
+contract = (request, status_validator, content_type_validator, response)
 positions = [lookup.find(fragment) for fragment in contract]
 
 if any(lookup.count(fragment) != 1 for fragment in contract):
-    raise SystemExit("Foursquare venue lookup must keep one request, 2xx validator, and JSON response handler.")
+    raise SystemExit("Foursquare venue lookup must keep one request, status validator, JSON media validator, and response handler.")
 if -1 in positions or positions != sorted(positions) or len(set(positions)) != len(positions):
-    raise SystemExit("Foursquare 2xx status validation must run before JSON response handling.")
+    raise SystemExit("Foursquare status and JSON media validation must run before response handling.")
 if lookup.count("case .failure:") != 1 or lookup.count(failure) != 1:
     raise SystemExit("Rejected Foursquare responses must retain the bounded generic failure retry.")
 PY
+
+if ! grep -Fq "application/json" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "media type before JSON response parsing" "$ROOT_DIR/README.md" ||
+  ! grep -Fq '`application/json`' "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "response media type" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "exact JSON response media type" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "exact application/json response media type" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "exact JSON response media type" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Repository guidance must document Foursquare JSON media validation." >&2
+  exit 1
+fi
 
 if ! grep -Fq "venueLatitude.isFinite" "$view" ||
   ! grep -Fq "(-90.0...90.0).contains(venueLatitude)" "$view" ||
@@ -681,6 +696,35 @@ if (
 ):
     raise SystemExit(
         "Foursquare response status plan must remain completed with actual verification recorded."
+    )
+PY
+
+python3 - "$RESPONSE_CONTENT_TYPE_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "validator removal mutation failed",
+    "media allowlist mutation failed",
+    "validation ordering mutation failed",
+    "duplicate handler mutation failed",
+    "failure retry mutation failed",
+    "plan evidence mutation failed",
+    "hosted pull-request check",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Foursquare response content-type plan must remain completed with actual verification recorded."
     )
 PY
 


### PR DESCRIPTION
## Summary

Require the exact `application/json` response media type before Alamofire invokes the Foursquare JSON handler.

## Baseline

This PR is stacked on `lfg/foursquare-response-status-validation-20260613` (PR #10). The base validates one 2xx status range before one `responseJSON` handler and preserves the generic bounded retry path, but successful non-JSON representations are not rejected explicitly.

## Improvements

- Add one exact `application/json` content-type validator after status validation and before response handling.
- Preserve the single request, single handler, and generic no-body-log retry path.
- Extend the static request-chain contract to reject removal, allowlist widening, ordering changes, duplicate handlers, retry removal, documentation drift, and incomplete evidence.
- Document the media boundary without changing the legacy Swift, CocoaPods, AR, location, credential, or project surfaces.

## Validation

- `make check`, `make lint`, `make test`, and `make build` passed the maintained static baseline.
- Six isolated mutations were rejected: validator removal, media allowlist widening, valid ordering swap, duplicate handler, failure retry removal, and plan-evidence removal.
- Shell syntax, plist/workspace XML parsing, executable-mode verification, and `git diff --check` passed.
- Intended-path artifact and secret scans found no generated files or embedded credentials.
- `xcodebuild`, CocoaPods installation, signing, simulator/device execution, camera, AR, location, Mapbox, and live Foursquare behavior are unavailable or intentionally unclaimed on this Linux host.
- Exact-head push run `27470711135` and pull-request run `27470714869`
  completed successfully on the hosted macOS check.
- PR #11 is OPEN, CLEAN, and MERGEABLE on the intended stacked base.
- Exact branch and `refs/pull/11/head` code-scanning queries returned zero open
  alerts.

## Risk

If the legacy Foursquare endpoint returns a vendor-specific JSON media type, the request will fail closed and use the existing bounded retry path. Any broader allowlist should be based on observed API documentation and device validation.

## Follow-Ups

- Keep this PR stacked on PR #10 and merge in base order only after explicit owner authorization.
- Verify the current live Foursquare media type with separately provisioned credentials on an era-compatible device/toolchain.
- Do not widen the media allowlist solely to suppress a generic retry without confirming the response contract.

## Post-Deploy Monitoring & Validation

After authorized merge, use the signed legacy toolchain and test credentials to confirm a normal venue response declares `application/json`, renders valid venues, and keeps rejected media types on the bounded retry path without raw-body logging. A documented vendor JSON type is the redesign trigger.
