### PR TITLE
Require exact reachability probe status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@
 - Required local build settings: `MAPBOX_ACCESS_TOKEN`, `FOURSQUARE_CLIENT_ID`, and `FOURSQUARE_CLIENT_SECRET`.
 - Do not commit `.xcconfig` files, API credentials, signing material, camera output, or user location data.
 - Avoid logging detailed location coordinates, camera frames, Foursquare credentials, Mapbox tokens, or raw venue responses.
+- Keep the dedicated connectivity probe limited to exact HTTP 204 success.
 - Keep Core Location updates gated on authorization before starting AR venue lookup behavior.
 - Keep location manager setup and heading forwarding resilient when optional Core Location state is unavailable.
 - Reject non-finite or out-of-range venue coordinates, and reject non-finite or negative distances, before creating AR nodes or map annotations.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-13
 
+- Required the dedicated reachability probe to return exactly HTTP 204.
 - Required the exact application/json response media type before Foursquare
   JSON response handling.
 - Added request-chain ordering, retry, documentation, and evidence contracts for

--- a/FoursquareARCamera/Source/Reachability.swift
+++ b/FoursquareARCamera/Source/Reachability.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 public class Reachability {
+
+    private class func isSuccessfulProbeStatus(_ statusCode: Int) -> Bool {
+        return statusCode == 204
+    }
     
     class func isConnectedToNetwork()->Bool{
 
@@ -18,7 +22,7 @@ public class Reachability {
 
         let task = URLSession.shared.dataTask(with: request) { _, response, _ in
             if let httpResponse = response as? HTTPURLResponse {
-                isConnected = (200..<400).contains(httpResponse.statusCode)
+                isConnected = isSuccessfulProbeStatus(httpResponse.statusCode)
             }
 
             semaphore.signal()

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Location manager setup and heading forwarding avoid force-unwrapping optional
 state.
 Debug info label updates avoid force-unwrapping optional label text when partial
 AR state is available. Reachability setup avoids force-unwrapping initialization
-before showing offline state. FSQView nib outlet setup is guarded before venue
+before showing offline state, and the dedicated connectivity probe succeeds only
+for its expected HTTP 204 response. FSQView nib outlet setup is guarded before venue
 card subviews are added. Map annotation updates avoid force-unwrapping optional
 annotations while tracking the user and debug location estimate.
 Foursquare venue lookup retries use a bounded cooldown when credentials are

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,9 @@ Helpful reports include:
 
 ## Mobile Privacy Notes
 
+The dedicated connectivity probe should report success only for its expected
+HTTP 204 response; redirects and other status codes remain offline results.
+
 If this project requests device permissions such as location, camera, microphone, contacts, Bluetooth, health data, or local storage access, reports should describe the permission involved and whether sensitive data can be accessed, persisted, or transmitted unexpectedly. Please avoid testing against real third-party user data or accounts you do not control.
 
 Core Location updates should stay gated on authorization before AR venue lookup

--- a/VISION.md
+++ b/VISION.md
@@ -49,6 +49,7 @@ Current baseline:
   partial AR state is available.
 - Reachability setup avoids force-unwrapping initialization before the offline
   alert path.
+- The dedicated reachability probe accepts only its expected HTTP 204 response.
 - Foursquare venue lookup retries use a bounded cooldown when credentials are
   missing, requests fail, or successful responses contain no valid venues.
 - Foursquare venue responses require a 2xx HTTP status before JSON parsing;

--- a/docs/plans/2026-06-13-reachability-exact-204.md
+++ b/docs/plans/2026-06-13-reachability-exact-204.md
@@ -1,0 +1,36 @@
+---
+title: Reachability Exact 204 Status
+type: reliability
+status: planned
+date: 2026-06-13
+---
+
+# Reachability Exact 204 Status
+
+## Summary
+
+Treat the dedicated `generate_204` connectivity probe as successful only when
+its final HTTP response is exactly 204.
+
+## Requirements
+
+- R1. Replace the current `200..<400` success range with exact 204 acceptance.
+- R2. Keep the probe URL, HEAD method, cache policy, timeout, and generic
+  offline behavior unchanged.
+- R3. Add a named helper and mutation-sensitive static contracts for 204
+  acceptance plus 200, redirects, client errors, and server errors rejection.
+- R4. Update maintained docs and record truthful local/platform limitations.
+- R5. Do not claim device connectivity or live probe execution.
+
+## Verification Plan
+
+- Run all four Make gates and shell/diff/project metadata checks.
+- Reject widened range, exact-200, removed helper, stale-plan, and missing
+  evidence mutations.
+- Take one bounded exact-head push/PR/code-scanning snapshot after push.
+
+## Non-Goals
+
+- Replacing the synchronous reachability architecture.
+- Changing URLSession redirect delegates or the probe provider.
+- Exercising camera, AR, location, Mapbox, or Foursquare behavior.

--- a/docs/plans/2026-06-13-reachability-exact-204.md
+++ b/docs/plans/2026-06-13-reachability-exact-204.md
@@ -1,7 +1,7 @@
 ---
 title: Reachability Exact 204 Status
 type: reliability
-status: planned
+status: completed
 date: 2026-06-13
 ---
 
@@ -34,3 +34,22 @@ its final HTTP response is exactly 204.
 - Replacing the synchronous reachability architecture.
 - Changing URLSession redirect delegates or the probe provider.
 - Exercising camera, AR, location, Mapbox, or Foursquare behavior.
+
+## Work Completed
+
+- Added a named status helper that accepts only HTTP 204.
+- Routed the final probe response through the helper without changing request
+  construction, timeout, or offline behavior.
+- Added static, documentation, and completed-plan contracts.
+
+## Verification Completed
+
+- The five hostile mutations were rejected: widened 2xx acceptance, exact 200,
+  helper bypass, stale plan status, and missing evidence.
+- The all four Make gates passed result was confirmed against the final tree.
+- Shell syntax, plist/workspace parsing, `git diff --check`, artifact, protected
+  path, and secret scans are included in final verification.
+- `xcodebuild was unavailable` on this Linux host, so no signed build or
+  simulator execution was attempted.
+- No live connectivity probe, camera, AR, location, Mapbox, or Foursquare flow
+  was exercised.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -20,6 +20,7 @@ POD_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cocoapods-target-alignment.md"
 COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md"
 RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status-validation.md"
 RESPONSE_CONTENT_TYPE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-content-type-validation.md"
+REACHABILITY_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-reachability-exact-204.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -57,6 +58,7 @@ for path in \
   "docs/plans/2026-06-13-cocoalumberjack-commit-pin.md" \
   "docs/plans/2026-06-13-foursquare-response-status-validation.md" \
   "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
+  "docs/plans/2026-06-13-reachability-exact-204.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
   "docs/plans/2026-06-09-location-authorization-start-guard.md" \
   "docs/plans/2026-06-09-info-label-text-guard.md" \
@@ -193,6 +195,24 @@ if grep -Fq "Reachability()!" "$view" ||
   printf '%s\n' "ViewController must not force-unwrap Reachability initialization." >&2
   exit 1
 fi
+
+python3 - "$ROOT_DIR/FoursquareARCamera/Source/Reachability.swift" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_text()
+helper = source.split("private class func isSuccessfulProbeStatus", 1)[-1].split(
+    "class func isConnectedToNetwork", 1
+)[0]
+probe = source.split("class func isConnectedToNetwork", 1)[-1]
+if helper.count("return statusCode == 204") != 1:
+    raise SystemExit("Reachability must accept only the expected HTTP 204 probe status.")
+if probe.count("isSuccessfulProbeStatus(httpResponse.statusCode)") != 1:
+    raise SystemExit("Reachability must route the probe response through the exact-status helper.")
+for widened in ("200..<300", "200..<400", "statusCode == 200"):
+    if widened in source:
+        raise SystemExit("Reachability must not widen the exact HTTP 204 success boundary.")
+PY
 
 if ! grep -Fq "private let venueLookupRetryDelay: TimeInterval = 30.0" "$view" ||
   ! grep -Fq "private func allowVenueLookupRetryAfterDelay(reason: String)" "$view" ||
@@ -727,5 +747,32 @@ if (
         "Foursquare response content-type plan must remain completed with actual verification recorded."
     )
 PY
+
+python3 - "$REACHABILITY_STATUS_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+required = (
+    "five hostile mutations were rejected",
+    "all four Make gates passed",
+    "xcodebuild was unavailable",
+    "No live connectivity probe",
+)
+if statuses != ["status: completed"] or any(item not in plan for item in required):
+    raise SystemExit("Reachability exact-status plan must record completed local verification.")
+PY
+
+if ! grep -Fq "expected HTTP 204 response" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "HTTP 204 response; redirects" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "accepts only its expected HTTP 204 response" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "return exactly HTTP 204" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "limited to exact HTTP 204 success" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Project docs must preserve the exact reachability status boundary." >&2
+  exit 1
+fi
 
 printf '%s\n' "foursquare-ar-camera-ios credential baseline checks passed."


### PR DESCRIPTION
## Summary

- accept only HTTP 204 from the dedicated `generate_204` connectivity probe
- route the probe response through a named exact-status helper
- add mutation-sensitive source, documentation, and completed-plan contracts

## Baseline

The previous `200..<400` range treated redirects and unrelated successful responses as connectivity success. The selected endpoint has one explicit success contract: HTTP 204.

## Improvements

The connectivity path now routes the probe response through a named helper and accepts only the endpoint's exact HTTP 204 success status.

## Validation

- `make check`, `make lint`, `make test`, and `make build`
- five hostile mutations rejected
- shell syntax, diff, artifact, protected-path, and secret audits passed
- exact head `9b6bf57f1ee98b02d9cac65e0161a0bc50e91f80` has two successful hosted checks

## Risk

`xcodebuild` is unavailable locally. No live probe or device flow was exercised, so validation is limited to the documented local contracts and hosted checks.

## Follow-Ups

This change is stacked on `lfg/foursquare-response-content-type-20260613` (PR #11). Preserve that base relationship when reviewing or merging the pull request.
