### PR TITLE
test: make Foursquare checks location independent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 2026-06-13
 
+- Made static verification independent of the caller's working directory by
+  resolving the baseline checker from the loaded Makefile.
 - Required the dedicated reachability probe to return exactly HTTP 204.
 - Required the exact application/json response media type before Foursquare
   JSON response handling.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .PHONY: build check lint test
 
+ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 lint test build: check
 
 check:
-	./scripts/check-baseline.sh
+	@"$(ROOT)/scripts/check-baseline.sh"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ make build
 make check
 ```
 
+Use the absolute Makefile path to run the same gates from another working
+directory. Verification resolves the checker relative to the loaded Makefile
+rather than the caller's directory.
+
 The `lint`, `test`, and `build` targets currently delegate to the static
 baseline so the repository has a consistent local gate even when Xcode is not
 installed. The baseline verifies that credentials are build settings, tracked

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -2,7 +2,7 @@
 title: Location-Independent Foursquare Verification
 type: reliability
 date: 2026-06-13
-status: planned
+status: completed
 execution: code
 ---
 
@@ -41,8 +41,23 @@ documented gate works when Make is invoked outside the checkout.
 
 ## Work Completed
 
-Pending implementation.
+- Derived the repository root from the loaded Makefile and invoked the static
+  checker through that absolute path.
+- Extended the baseline with rooted-Makefile, completed-plan, external-run, and
+  synchronized-guidance contracts.
+- Preserved all Objective-C, Swift, Xcode project/workspace, CocoaPods, plist,
+  storyboard, asset, reachability, response-validation, privacy, workflow, and
+  signing surfaces unchanged.
 
 ## Verification Completed
 
-Pending implementation and verification.
+- `make check`, `make lint`, `make test`, and `make build` passed at repository
+  root.
+- The full gate passed from /tmp through the absolute Makefile path.
+- Five isolated hostile root-derivation, checker-path, documentation,
+  plan-status, and verification-evidence mutations were rejected.
+- Shell syntax, plist/XML parsing, `git diff --check`, exact-path review,
+  added-line secret/signing inspection, and generated-artifact inspection
+  passed.
+- Xcode build, simulator, device, camera, location, and live Foursquare behavior
+  were unavailable and are not claimed.

--- a/docs/plans/2026-06-13-location-independent-make.md
+++ b/docs/plans/2026-06-13-location-independent-make.md
@@ -1,0 +1,48 @@
+---
+title: Location-Independent Foursquare Verification
+type: reliability
+date: 2026-06-13
+status: planned
+execution: code
+---
+
+# Location-Independent Foursquare Verification
+
+## Summary
+
+Resolve the maintained static checker from the loaded Makefile so every
+documented gate works when Make is invoked outside the checkout.
+
+## Requirements
+
+- R1. Derive the repository root from `MAKEFILE_LIST`.
+- R2. Invoke `scripts/check-baseline.sh` through its repository-rooted path.
+- R3. Add a static contract that rejects caller-directory-relative invocation.
+- R4. Preserve all Objective-C, project, workspace, CocoaPods, plist,
+  reachability, Foursquare response, privacy, workflow, and signing surfaces.
+- R5. Record actual root and external-directory verification before completion.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build` at repository
+  root.
+- Run the full gate from `/tmp` through the absolute Makefile path.
+- Reject isolated hostile root-derivation, checker-path, documentation,
+  plan-status, and verification-evidence mutations.
+- Run shell syntax, plist/XML parsing, `git diff --check`, exact-path review,
+  secret/signing inspection, and generated-artifact inspection.
+
+## Non-Goals
+
+- Changing application runtime, dependencies, projects, signing, API behavior,
+  reachability behavior, or response validation.
+- Claiming Xcode build, simulator, device, camera, location, or live Foursquare
+  execution.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and verification.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -21,6 +21,7 @@ COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit
 RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status-validation.md"
 RESPONSE_CONTENT_TYPE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-content-type-validation.md"
 REACHABILITY_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-reachability-exact-204.md"
+LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
 
 require_file() {
@@ -59,6 +60,7 @@ for path in \
   "docs/plans/2026-06-13-foursquare-response-status-validation.md" \
   "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
   "docs/plans/2026-06-13-reachability-exact-204.md" \
+  "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
   "docs/plans/2026-06-09-location-authorization-start-guard.md" \
   "docs/plans/2026-06-09-info-label-text-guard.md" \
@@ -69,6 +71,20 @@ for path in \
   "docs/plans/2026-06-08-foursquare-ar-camera-ios-credential-baseline.md"; do
   require_file "$path"
 done
+
+if ! grep -Fq 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||
+  ! grep -Fq '"$(ROOT)/scripts/check-baseline.sh"' "$ROOT_DIR/Makefile"; then
+  printf '%s\n' "Makefile verification must resolve the checker from the loaded Makefile." >&2
+  exit 1
+fi
+
+if ! grep -Fq "status: completed" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "from /tmp" "$LOCATION_INDEPENDENT_MAKE_PLAN" ||
+  ! grep -Fq "absolute Makefile path" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Made static verification independent" "$ROOT_DIR/CHANGES.md"; then
+  printf '%s\n' "Location-independent Make plan and guidance must record completed external verification." >&2
+  exit 1
+fi
 
 makefile="$ROOT_DIR/Makefile"
 if ! grep -Eq '^\.PHONY: .*build.*check.*lint.*test|^\.PHONY: .*build.*lint.*test.*check' "$makefile" ||


### PR DESCRIPTION
## Summary

All documented static verification gates now work when Make is invoked outside
the repository checkout. Previously, an absolute Makefile invocation resolved
the checker against the caller's directory and exited 127.

## Baseline

`make -f <absolute Makefile> -C /tmp check` attempted to execute
`./scripts/check-baseline.sh` from `/tmp`, so none of the maintained iOS,
CocoaPods, privacy, response-validation, or workflow contracts ran.

## Improvements

- Resolve the repository root from the loaded Makefile.
- Invoke the maintained checker through its repository-rooted absolute path.
- Enforce rooted invocation, completed plan evidence, and synchronized guidance
  with mutation-sensitive contracts.
- Preserve all Objective-C, Swift, project/workspace, CocoaPods, plist,
  storyboard, asset, reachability, response-validation, privacy, workflow, and
  signing surfaces.

## Validation

- `make check`, `make lint`, `make test`, and `make build` at repository root
  and from `/tmp` through the absolute Makefile path
- Shell syntax and plist/workspace XML parsing
- Five isolated hostile mutations covering root derivation, checker path,
  documentation, plan status, and external-run evidence
- `git diff --check`, exact intended-path review, added-line secret/signing scan,
  protected-project diff, and generated-artifact scan
- Sequential plan-aware review: actionable findings none
- Browser testing: not applicable because no browser surface changed

## Risk

Low. The change only affects verification path resolution. It does not change
application runtime, dependencies, projects, signing, reachability, API response
handling, or privacy behavior. Xcode build, simulator, device, camera, location,
and live Foursquare behavior were unavailable and are not claimed. This PR is
stacked and depends on PR #12 remaining available first.

## Follow-Ups

- Require terminal exact-head hosted checks before merge.
- Merge only after the stacked base is available and with explicit owner
  authorization.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this change affects only
offline developer/CI verification path resolution. The owner should confirm the
exact-head push and pull-request checks remain green before merge; any failed
gate is the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
