### PR TITLE
Validate Foursquare response provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@
 - Keep credential, request, malformed-response, and empty-response retries bounded by the documented cooldown.
 - Require a 2xx Foursquare response status before JSON parsing, and keep
   rejected responses on the generic no-body-log retry path.
+- Require the exact final HTTPS Foursquare API endpoint after status validation
+  and before response media validation.
 - Require the exact JSON response media type after status validation and before
   response handling.
 - Treat Swift, CocoaPods, Mapbox, ARKit/Core Location, and Foursquare API modernization as staged, device-verified work; update `Podfile.lock` only with an intentional dependency and CocoaPods toolchain review.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-14
+
+- Required the exact final HTTPS Foursquare API endpoint before response media
+  validation or JSON handling.
+- Added scheme, host, userinfo, port, path, fragment, ordering, retry,
+  documentation, and completed-evidence contracts for response provenance.
+
 ## 2026-06-13
 
 - Made static verification independent of the caller's working directory by

--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -195,6 +195,21 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
             // Send HTTP request
             Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)
                 .validate(statusCode: 200..<300)
+                .validate { _, response, _ in
+                    guard let finalURL = response.url,
+                        let components = URLComponents(url: finalURL, resolvingAgainstBaseURL: false),
+                        components.scheme == "https",
+                        components.host == "api.foursquare.com",
+                        components.user == nil,
+                        components.password == nil,
+                        components.port == nil,
+                        components.percentEncodedPath == "/v2/venues/search",
+                        components.fragment == nil else {
+                        return .failure(NSError(domain: "FoursquareResponseValidation", code: 1, userInfo: nil))
+                    }
+
+                    return .success
+                }
                 .validate(contentType: ["application/json"])
                 .responseJSON { response in
                 switch response.result {

--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ card subviews are added. Map annotation updates avoid force-unwrapping optional
 annotations while tracking the user and debug location estimate.
 Foursquare venue lookup retries use a bounded cooldown when credentials are
 missing, requests fail, or successful responses contain no valid venue payloads.
-Venue lookups validate a 2xx HTTP status and exact application/json response
-media type before JSON response parsing; rejected responses use the same
-generic bounded retry path without logging response data.
+Venue lookups validate a 2xx HTTP status and the final HTTPS
+api.foursquare.com endpoint and exact path. They also require the exact
+application/json response media type before JSON response parsing; rejected
+responses use the same generic bounded retry path without logging response
+data.
 Venue responses also require finite latitude/longitude within geographic bounds
 and a finite nonnegative distance before rendering.
 
@@ -181,6 +183,8 @@ When the required SDK or runtime is unavailable, use static checks and source re
   lookup retry guardrails.
 - See `docs/plans/2026-06-13-foursquare-response-content-type-validation.md`
   for the exact JSON response media boundary.
+- See `docs/plans/2026-06-14-foursquare-response-final-url-validation.md` for
+  the final Foursquare response URL boundary.
 - See `docs/plans/2026-06-10-legacy-sdk-modernization-boundary.md` for the
   legacy SDK and dependency modernization sequence.
 - See `docs/plans/2026-06-12-hosted-project-validation.md` for the GitHub

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,10 +51,11 @@ while displaying user or debug location markers.
 Foursquare venue lookup retries should stay bounded so missing credentials,
 failed requests, or empty/malformed responses do not create immediate request
 loops while location updates continue.
-Foursquare venue responses should require a 2xx HTTP status and exact
-`application/json` response media type before JSON parsing; rejected responses
-must use the generic retry path without logging bodies, credentials, request
-URLs, or location details.
+Foursquare venue responses should require a 2xx HTTP status, an exact final
+response URL at the HTTPS `api.foursquare.com/v2/venues/search` endpoint, and
+the exact `application/json` response media type before JSON parsing; rejected
+responses must use the generic retry path without logging bodies, credentials,
+request URLs, redirect targets, or location details.
 Foursquare venue coordinates should be finite and geographically bounded, and
 distance values should be finite and nonnegative before AR or map rendering.
 

--- a/VISION.md
+++ b/VISION.md
@@ -54,6 +54,8 @@ Current baseline:
   missing, requests fail, or successful responses contain no valid venues.
 - Foursquare venue responses require a 2xx HTTP status before JSON parsing;
   rejected statuses use the existing generic bounded retry path.
+- Successful venue responses require the exact final HTTPS endpoint before
+  media validation or response handling.
 - Successful venue responses require the exact JSON response media type before
   response handling.
 - Venue response coordinates and distances are finite and range-checked before
@@ -88,6 +90,7 @@ Next priorities:
 - Preserve bounded Foursquare venue lookup retries when changing API failure
   handling
 - Preserve 2xx status validation ahead of Foursquare JSON response parsing
+- Preserve exact final HTTPS endpoint validation ahead of media validation
 - Preserve exact JSON response media type validation ahead of response handling
 - Keep local verification targets available even while full Xcode testing needs
   a macOS toolchain

--- a/docs/plans/2026-06-14-foursquare-response-final-url-validation.md
+++ b/docs/plans/2026-06-14-foursquare-response-final-url-validation.md
@@ -1,7 +1,7 @@
 ---
 title: Foursquare Response Final URL Validation
 type: security
-status: planned
+status: completed
 date: 2026-06-14
 ---
 
@@ -87,8 +87,32 @@ Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
 
 ## Work Completed
 
-- Not yet implemented.
+- Added an Alamofire validator that requires the final response URL to use the
+  exact HTTPS Foursquare API host and path without userinfo, an explicit port,
+  or a fragment.
+- Kept final URL validation between the existing status and media validators so
+  rejected redirects reach the generic bounded retry before JSON handling.
+- Extended the static request-chain contract and repository guidance for final
+  URL provenance and continuing platform/live-validation limits.
 
 ## Verification Completed
 
-- Not yet run.
+- All four Make gates passed the maintained static baseline from the repository
+  root, and the absolute-Makefile check passed from an external directory.
+- The validator removal mutation failed the single-chain contract.
+- The scheme mutation failed the exact HTTPS endpoint contract.
+- The host mutation failed the exact Foursquare host contract.
+- The path mutation failed the exact venue-search path contract.
+- The port mutation failed the no-explicit-port contract.
+- The validation ordering mutation failed after moving final URL validation
+  behind media validation.
+- The failure retry mutation failed the bounded generic retry contract.
+- The plan evidence mutation failed the completed-evidence contract.
+- Shell syntax, plist/workspace XML parsing, executable-mode verification,
+  `git diff --check`, and intended-file secret and artifact scans are included
+  in final-tree verification.
+- `xcodebuild`, CocoaPods installation, signing, simulator/device execution,
+  camera, AR, location, Mapbox, and live Foursquare behavior are unavailable or
+  intentionally unclaimed on this Linux host.
+- The hosted pull-request check and code-scanning snapshot will be recorded
+  against the exact pushed head in the external engineering tracker.

--- a/docs/plans/2026-06-14-foursquare-response-final-url-validation.md
+++ b/docs/plans/2026-06-14-foursquare-response-final-url-validation.md
@@ -1,0 +1,94 @@
+---
+title: Foursquare Response Final URL Validation
+type: security
+status: planned
+date: 2026-06-14
+---
+
+# Foursquare Response Final URL Validation
+
+## Summary
+
+Require successful Foursquare venue responses to finish at the exact HTTPS API
+endpoint before Alamofire validates media metadata or invokes JSON parsing.
+
+## Priority
+
+1. Reject redirected or otherwise unexpected final response origins and paths.
+2. Preserve the existing single request, 2xx status, JSON media, and bounded
+   retry behavior.
+3. Keep the legacy Swift 4, Alamofire, CocoaPods, AR, location, and credential
+   boundaries unchanged.
+
+## Requirements
+
+- R1. A single custom Alamofire validator must require the final response URL
+  to use `https`, host `api.foursquare.com`, have no explicit port, and use the
+  exact `/v2/venues/search` path.
+- R2. Final URL validation must run after the 2xx status validator and before
+  content-type validation and the single `responseJSON` handler.
+- R3. Rejected final URLs must reach the existing generic failure retry path
+  without logging response content or redirect targets.
+- R4. Static contracts must reject validator removal, scheme/host/path/port
+  weakening, reordered validation, duplicate requests or handlers, weakened
+  retry behavior, documentation drift, or incomplete plan evidence.
+- R5. README, SECURITY, VISION, CHANGES, and AGENTS must describe the final URL
+  boundary without claiming live API or device validation.
+- R6. The completed plan must record actual local, mutation, and hosted
+  verification evidence.
+
+## Non-Goals
+
+- Changing the Foursquare endpoint, parameters, credentials, API version,
+  success status range, or JSON media allowlist.
+- Disabling redirects globally or changing Alamofire session configuration.
+- Changing venue parsing, coordinate validation, AR rendering, map annotations,
+  retries, or logging.
+- Updating Swift, iOS, Alamofire, CocoaPods, Mapbox, or project metadata.
+- Claiming compilation, signing, simulator/device, camera, location, or live
+  Foursquare validation from this Linux host.
+
+## Implementation Units
+
+### 1. Alamofire Final URL Validator
+
+Files: `FoursquareARCamera/ViewController.swift`
+
+- Add an exact scheme, host, port, and path validator between status and media
+  validation.
+
+### 2. Static Contracts
+
+Files: `scripts/check-baseline.sh`
+
+- Require one request, one status validator, one exact final URL validator, one
+  JSON media validator, one response handler, exact ordering, generic failure
+  retry behavior, documentation, and completed evidence.
+
+### 3. Repository Guidance
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
+
+- Record the response-provenance boundary and continuing platform/live
+  validation limits.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build` from the
+  repository root, plus `make check` through the absolute Makefile path from an
+  external directory.
+- Remove the validator, weaken scheme/host/path/port checks, move it after
+  content-type validation, duplicate the handler, remove failure retry, and
+  regress plan evidence; each mutation must be rejected.
+- Run shell syntax, plist/workspace XML parsing, executable-mode checks,
+  `git diff --check`, and intended-file secret/artifact scans.
+- Take one bounded exact-head pull-request and code-scanning snapshot after
+  push; do not start a watch loop.
+
+## Work Completed
+
+- Not yet implemented.
+
+## Verification Completed
+
+- Not yet run.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -20,6 +20,7 @@ POD_TARGET_PLAN="$ROOT_DIR/docs/plans/2026-06-12-cocoapods-target-alignment.md"
 COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit-pin.md"
 RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status-validation.md"
 RESPONSE_CONTENT_TYPE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-content-type-validation.md"
+RESPONSE_FINAL_URL_PLAN="$ROOT_DIR/docs/plans/2026-06-14-foursquare-response-final-url-validation.md"
 REACHABILITY_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-reachability-exact-204.md"
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
@@ -59,6 +60,7 @@ for path in \
   "docs/plans/2026-06-13-cocoalumberjack-commit-pin.md" \
   "docs/plans/2026-06-13-foursquare-response-status-validation.md" \
   "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
+  "docs/plans/2026-06-14-foursquare-response-final-url-validation.md" \
   "docs/plans/2026-06-13-reachability-exact-204.md" \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
@@ -163,19 +165,41 @@ source = Path(sys.argv[1]).read_text()
 lookup = source.split("func getFoursquareLocations", 1)[-1].split("\n    @objc", 1)[0]
 request = 'Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)'
 status_validator = ".validate(statusCode: 200..<300)"
+final_url_validator = ".validate { _, response, _ in"
 content_type_validator = '.validate(contentType: ["application/json"])'
 response = ".responseJSON { response in"
 failure = 'self.allowVenueLookupRetryAfterDelay(reason: "Foursquare venue lookup failed.")'
-contract = (request, status_validator, content_type_validator, response)
+contract = (request, status_validator, final_url_validator, content_type_validator, response)
 positions = [lookup.find(fragment) for fragment in contract]
 
 if any(lookup.count(fragment) != 1 for fragment in contract):
-    raise SystemExit("Foursquare venue lookup must keep one request, status validator, JSON media validator, and response handler.")
+    raise SystemExit("Foursquare venue lookup must keep one request, status validator, final URL validator, JSON media validator, and response handler.")
 if -1 in positions or positions != sorted(positions) or len(set(positions)) != len(positions):
-    raise SystemExit("Foursquare status and JSON media validation must run before response handling.")
+    raise SystemExit("Foursquare status, final URL, and JSON media validation must run before response handling.")
+final_url_contract = (
+    'components.scheme == "https"',
+    'components.host == "api.foursquare.com"',
+    "components.user == nil",
+    "components.password == nil",
+    "components.port == nil",
+    'components.percentEncodedPath == "/v2/venues/search"',
+    "components.fragment == nil",
+    'NSError(domain: "FoursquareResponseValidation", code: 1, userInfo: nil)',
+)
+if any(lookup.count(fragment) != 1 for fragment in final_url_contract):
+    raise SystemExit("Foursquare final response URL validation must preserve the exact HTTPS endpoint boundary.")
 if lookup.count("case .failure:") != 1 or lookup.count(failure) != 1:
     raise SystemExit("Rejected Foursquare responses must retain the bounded generic failure retry.")
 PY
+
+if ! grep -Fq "api.foursquare.com endpoint and exact path" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "response URL at the HTTPS" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "exact final HTTPS endpoint" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "exact final HTTPS Foursquare API endpoint" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "exact final HTTPS Foursquare API endpoint" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Repository guidance must document Foursquare final response URL validation." >&2
+  exit 1
+fi
 
 if ! grep -Fq "application/json" "$ROOT_DIR/README.md" ||
   ! grep -Fq "media type before JSON response parsing" "$ROOT_DIR/README.md" ||
@@ -761,6 +785,37 @@ if (
 ):
     raise SystemExit(
         "Foursquare response content-type plan must remain completed with actual verification recorded."
+    )
+PY
+
+python3 - "$RESPONSE_FINAL_URL_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "validator removal mutation failed",
+    "scheme mutation failed",
+    "host mutation failed",
+    "path mutation failed",
+    "port mutation failed",
+    "validation ordering mutation failed",
+    "failure retry mutation failed",
+    "plan evidence mutation failed",
+    "hosted pull-request check",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Foursquare response final URL plan must remain completed with actual verification recorded."
     )
 PY
 


### PR DESCRIPTION
## Summary

Foursquare venue responses now have to finish at the exact HTTPS API endpoint
before media validation or JSON handling. Redirected or otherwise unexpected
origins and paths use the existing generic bounded retry without logging body
or redirect details.

## Baseline

The existing request chain validated a 2xx status and `application/json`, but it
accepted the final response URL selected after redirects without checking its
scheme, authority, or path.

## Improvements

- Require `https://api.foursquare.com/v2/venues/search` as the exact final
  response endpoint while allowing the request query parameters.
- Reject userinfo, explicit ports, fragments, alternate hosts, schemes, and
  paths before media validation and JSON handling.
- Preserve the single request, 2xx status boundary, exact JSON media boundary,
  and generic bounded retry path.
- Add mutation-sensitive request ordering, endpoint, guidance, and completed
  plan evidence contracts.

## Validation

- `make check`, `make lint`, `make test`, and `make build` from the repository
  root
- `make -f <absolute Makefile> check` from `/tmp`
- Nine isolated hostile mutations covering validator removal, scheme, host,
  path, port, ordering, failure retry, plan status, and plan evidence
- Shell syntax, plist/workspace XML parsing, exact intended-path review,
  generated-artifact scan, changed-line credential scan, and `git diff --check`
- Main-thread correctness, testing, security, and reliability review:
  actionable findings none
- Browser testing: not applicable because no browser surface changed

## Risk

Low and localized to Foursquare response acceptance. A provider redirect to a
different endpoint will now fail closed and retry after the existing cooldown.
Xcode build, CocoaPods installation, simulator/device, camera, AR, location,
Mapbox, and live Foursquare behavior were unavailable on Linux and are not
claimed. This PR is stacked and depends on PR #13 remaining available first.

## Follow-Ups

- Require terminal exact-head hosted checks before merge.
- Merge only after the stacked base is available and with explicit owner
  authorization.

## Post-Deploy Monitoring & Validation

On an era-compatible macOS/Xcode setup, confirm a normal venue lookup succeeds
and an unexpected redirect follows the existing delayed retry path without
response logging. Any exact-head CI failure or live endpoint incompatibility is
the rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
