### PR TITLE
Refuse redirects for Foursquare venue requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@
 - Keep location manager setup and heading forwarding resilient when optional Core Location state is unavailable.
 - Reject non-finite or out-of-range venue coordinates, and reject non-finite or negative distances, before creating AR nodes or map annotations.
 - Keep credential, request, malformed-response, and empty-response retries bounded by the documented cooldown.
+- Require Foursquare venue requests to refuse redirects before forwarding credential-bearing query parameters.
 - Require a 2xx Foursquare response status before JSON parsing, and keep
   rejected responses on the generic no-body-log retry path.
 - Require the exact final HTTPS Foursquare API endpoint after status validation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 2026-06-15
+
+- Refused redirects for credential-bearing Foursquare venue requests before
+  URLSession can forward their query parameters.
+- Added dedicated-session, redirect-policy, request-routing, documentation, and
+  completed-evidence contracts.
+
 ## 2026-06-14
 
 - Required the exact final HTTPS Foursquare API endpoint before response media

--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -45,6 +45,13 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
     var loaded: Bool = false
     private let venueLookupRetryDelay: TimeInterval = 30.0
     private var hasVenueTapGesture = false
+    private let foursquareSessionManager: SessionManager = {
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
+        let manager = SessionManager(configuration: configuration)
+        manager.delegate.taskWillPerformHTTPRedirection = { _, _, _, _ in nil }
+        return manager
+    }()
     
     var adjustNorthByTappingSidesOfScreen = false
 
@@ -193,7 +200,7 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
             ]
             
             // Send HTTP request
-            Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)
+            self.foursquareSessionManager.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)
                 .validate(statusCode: 200..<300)
                 .validate { _, response, _ in
                     guard let finalURL = response.url,

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ card subviews are added. Map annotation updates avoid force-unwrapping optional
 annotations while tracking the user and debug location estimate.
 Foursquare venue lookup retries use a bounded cooldown when credentials are
 missing, requests fail, or successful responses contain no valid venue payloads.
-Venue lookups validate a 2xx HTTP status and the final HTTPS
-api.foursquare.com endpoint and exact path. They also require the exact
+Venue lookup refuses redirects before sending venue query credentials, then
+validates a 2xx HTTP status and the final HTTPS
+api.foursquare.com endpoint and exact path. It also requires the exact
 application/json response media type before JSON response parsing; rejected
 responses use the same generic bounded retry path without logging response
 data.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,8 @@ while displaying user or debug location markers.
 Foursquare venue lookup retries should stay bounded so missing credentials,
 failed requests, or empty/malformed responses do not create immediate request
 loops while location updates continue.
+Credential-bearing Foursquare venue requests must refuse redirects before a
+redirect destination can receive their query parameters.
 Foursquare venue responses should require a 2xx HTTP status, an exact final
 response URL at the HTTPS `api.foursquare.com/v2/venues/search` endpoint, and
 the exact `application/json` response media type before JSON parsing; rejected

--- a/VISION.md
+++ b/VISION.md
@@ -52,6 +52,8 @@ Current baseline:
 - The dedicated reachability probe accepts only its expected HTTP 204 response.
 - Foursquare venue lookup retries use a bounded cooldown when credentials are
   missing, requests fail, or successful responses contain no valid venues.
+- Venue lookup refuses redirects before credentials can be forwarded to a
+  redirect destination.
 - Foursquare venue responses require a 2xx HTTP status before JSON parsing;
   rejected statuses use the existing generic bounded retry path.
 - Successful venue responses require the exact final HTTPS endpoint before

--- a/docs/plans/2026-06-15-foursquare-redirect-refusal.md
+++ b/docs/plans/2026-06-15-foursquare-redirect-refusal.md
@@ -1,0 +1,91 @@
+---
+title: Foursquare Redirect Refusal
+type: security
+status: in_progress
+date: 2026-06-15
+---
+
+# Foursquare Redirect Refusal
+
+## Summary
+
+Refuse HTTP redirects for the credential-bearing Foursquare venue request so
+URLSession cannot forward its query parameters to another destination.
+
+## Priority
+
+1. Prevent Foursquare client credentials from being forwarded across redirects.
+2. Preserve exact final-response URL, status, media-type, and bounded retry
+   validation as defense in depth.
+3. Keep the pinned Swift 4, Alamofire 4.5.1, CocoaPods, and iOS 11 boundaries.
+
+## Requirements
+
+- R1. Venue lookup must use one dedicated `SessionManager` whose Alamofire
+  redirect delegate returns `nil` for every redirect.
+- R2. The dedicated manager must issue the existing single venue request; the
+  global Alamofire manager and unrelated URLSession traffic must not change.
+- R3. A refused redirect must flow through the existing non-2xx validation and
+  generic bounded retry without logging URLs, credentials, or response bodies.
+- R4. The exact final URL validator must remain after status validation and
+  before media validation and JSON handling.
+- R5. Static contracts must reject manager removal, redirect-policy weakening,
+  fallback to the global request helper, chain duplication, retry weakening,
+  documentation drift, and incomplete plan evidence.
+- R6. The completed plan must record actual local, mutation, and hosted
+  verification evidence without claiming unavailable Apple-platform execution.
+
+## Non-Goals
+
+- Rotating credentials or changing their local configuration mechanism.
+- Changing the Foursquare endpoint, parameters, API version, success status
+  range, JSON media allowlist, response schema, retry delay, or UI behavior.
+- Updating Swift, iOS, Alamofire, CocoaPods, Mapbox, or project metadata.
+- Claiming compilation, signing, simulator/device, camera, location, or live
+  Foursquare validation from this Linux host.
+
+## Implementation Units
+
+### 1. Dedicated Redirect-Refusing Session
+
+Files: `FoursquareARCamera/ViewController.swift`
+
+- Construct one private `SessionManager` with the default Alamofire headers.
+- Set `taskWillPerformHTTPRedirection` to return `nil`.
+- Issue venue requests through that manager.
+
+### 2. Static Contracts
+
+Files: `scripts/check-baseline.sh`
+
+- Require the dedicated manager, exact redirect refusal, single request chain,
+  existing validation ordering, generic failure retry, and completed evidence.
+
+### 3. Repository Guidance
+
+Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
+
+- Record redirect refusal for credential-bearing venue requests and the
+  continuing legacy platform and live-validation limits.
+
+## Verification Plan
+
+- Run `make check`, `make lint`, `make test`, and `make build` from the
+  repository root, plus `make check` through the absolute Makefile path from an
+  external directory.
+- Remove the dedicated manager, permit the redirected request, fall back to
+  `Alamofire.request`, duplicate the request, remove final URL validation,
+  weaken failure retry, and regress completed evidence; each mutation must be
+  rejected.
+- Run shell syntax, plist/workspace XML parsing, executable-mode checks,
+  `git diff --check`, and intended-file secret and artifact scans.
+- Take one bounded exact-head pull-request and code-scanning snapshot after
+  push; do not start a watch loop.
+
+## Work Completed
+
+Pending implementation.
+
+## Verification Completed
+
+Pending implementation and validation.

--- a/docs/plans/2026-06-15-foursquare-redirect-refusal.md
+++ b/docs/plans/2026-06-15-foursquare-redirect-refusal.md
@@ -1,7 +1,7 @@
 ---
 title: Foursquare Redirect Refusal
 type: security
-status: in_progress
+status: completed
 date: 2026-06-15
 ---
 
@@ -84,8 +84,31 @@ Files: `README.md`, `SECURITY.md`, `VISION.md`, `CHANGES.md`, `AGENTS.md`
 
 ## Work Completed
 
-Pending implementation.
+- Added a dedicated Alamofire `SessionManager` for Foursquare venue lookup with
+  the standard Alamofire headers and a redirect delegate that always returns
+  `nil`.
+- Routed the existing single credential-bearing venue request through that
+  manager while retaining status, final URL, media-type, JSON, and bounded
+  retry behavior.
+- Extended static contracts and maintained guidance for redirect refusal and
+  the continuing legacy platform/live-validation limits.
 
 ## Verification Completed
 
-Pending implementation and validation.
+- All four Make gates passed the maintained static baseline from an isolated
+  copy of the exact source tree, and the absolute-Makefile check passed from an
+  external directory.
+- The manager removal mutation failed the dedicated-session contract.
+- The redirect policy mutation failed after permitting the redirected request.
+- The global request helper mutation failed after bypassing the dedicated
+  session manager.
+- The duplicate request mutation failed the single-chain contract.
+- The final URL validator mutation failed the response-provenance contract.
+- The failure retry mutation failed the bounded generic retry contract.
+- The plan evidence mutation failed the completed-evidence contract.
+- Shell syntax and `git diff --check` passed before final-tree verification.
+- `xcodebuild`, CocoaPods installation, signing, simulator/device execution,
+  camera, AR, location, Mapbox, and live Foursquare behavior are unavailable or
+  intentionally excluded on this Linux host.
+- The hosted pull-request check is captured after push and recorded in the
+  exact-head tracker evidence rather than claimed by this pre-push plan.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -21,6 +21,7 @@ COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit
 RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status-validation.md"
 RESPONSE_CONTENT_TYPE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-content-type-validation.md"
 RESPONSE_FINAL_URL_PLAN="$ROOT_DIR/docs/plans/2026-06-14-foursquare-response-final-url-validation.md"
+RESPONSE_REDIRECT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-foursquare-redirect-refusal.md"
 REACHABILITY_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-reachability-exact-204.md"
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
@@ -61,6 +62,7 @@ for path in \
   "docs/plans/2026-06-13-foursquare-response-status-validation.md" \
   "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
   "docs/plans/2026-06-14-foursquare-response-final-url-validation.md" \
+  "docs/plans/2026-06-15-foursquare-redirect-refusal.md" \
   "docs/plans/2026-06-13-reachability-exact-204.md" \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
@@ -149,7 +151,8 @@ view="$ROOT_DIR/FoursquareARCamera/ViewController.swift"
 if ! grep -Fq 'configuredValue("FoursquareClientID")' "$view" ||
   ! grep -Fq 'configuredValue("FoursquareClientSecret")' "$view" ||
   ! grep -Fq "Skipping malformed Foursquare venue response" "$view" ||
-  ! grep -Fq 'Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)' "$view" ||
+  ! grep -Fq 'self.foursquareSessionManager.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)' "$view" ||
+  grep -Fq 'Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)' "$view" ||
   grep -Eq 'let client_(id|secret) = ""|client_secret=|client_id=' "$view" ||
   grep -Eq '\["(name|location)"\].*\!|\["categories"\]\[0\]' "$view" ||
   grep -Eq 'DDLogDebug\(.*(coordinate|currentLocation|translated location|best location estimate|altitude)' "$view"; then
@@ -163,7 +166,17 @@ from pathlib import Path
 
 source = Path(sys.argv[1]).read_text()
 lookup = source.split("func getFoursquareLocations", 1)[-1].split("\n    @objc", 1)[0]
-request = 'Alamofire.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)'
+manager_contract = (
+    "private let foursquareSessionManager: SessionManager = {",
+    "let configuration = URLSessionConfiguration.default",
+    "configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders",
+    "let manager = SessionManager(configuration: configuration)",
+    "manager.delegate.taskWillPerformHTTPRedirection = { _, _, _, _ in nil }",
+    "return manager",
+)
+if any(source.count(fragment) != 1 for fragment in manager_contract):
+    raise SystemExit("Foursquare venue lookup must use one dedicated redirect-refusing Alamofire session manager.")
+request = 'self.foursquareSessionManager.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)'
 status_validator = ".validate(statusCode: 200..<300)"
 final_url_validator = ".validate { _, response, _ in"
 content_type_validator = '.validate(contentType: ["application/json"])'
@@ -191,6 +204,15 @@ if any(lookup.count(fragment) != 1 for fragment in final_url_contract):
 if lookup.count("case .failure:") != 1 or lookup.count(failure) != 1:
     raise SystemExit("Rejected Foursquare responses must retain the bounded generic failure retry.")
 PY
+
+if ! grep -Fq "refuses redirects before sending venue query credentials" "$ROOT_DIR/README.md" ||
+  ! grep -Fq "Credential-bearing Foursquare venue requests must refuse redirects" "$ROOT_DIR/SECURITY.md" ||
+  ! grep -Fq "Venue lookup refuses redirects before credentials can be forwarded" "$ROOT_DIR/VISION.md" ||
+  ! grep -Fq "Refused redirects for credential-bearing Foursquare venue requests" "$ROOT_DIR/CHANGES.md" ||
+  ! grep -Fq "refuse redirects before forwarding credential-bearing query parameters" "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Repository guidance must document Foursquare redirect refusal." >&2
+  exit 1
+fi
 
 if ! grep -Fq "api.foursquare.com endpoint and exact path" "$ROOT_DIR/README.md" ||
   ! grep -Fq "response URL at the HTTPS" "$ROOT_DIR/SECURITY.md" ||
@@ -816,6 +838,36 @@ if (
 ):
     raise SystemExit(
         "Foursquare response final URL plan must remain completed with actual verification recorded."
+    )
+PY
+
+python3 - "$RESPONSE_REDIRECT_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "manager removal mutation failed",
+    "redirect policy mutation failed",
+    "global request helper mutation failed",
+    "duplicate request mutation failed",
+    "final URL validator mutation failed",
+    "failure retry mutation failed",
+    "plan evidence mutation failed",
+    "hosted pull-request check",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Foursquare redirect refusal plan must remain completed with actual verification recorded."
     )
 PY
 


### PR DESCRIPTION
## Summary

Refuse HTTP redirects for the credential-bearing Foursquare venue lookup before URLSession can forward query parameters to another destination.

This is stacked on #14 so the existing exact final-response URL validator remains defense in depth after the redirect boundary.

## Baseline

The pinned Alamofire 4.5.1 request used the shared manager and followed redirects by default. Final URL validation rejected an unexpected destination only after URLSession had already followed the redirect.

## Improvements

- Add one dedicated `SessionManager` with Alamofire's standard default headers.
- Set `taskWillPerformHTTPRedirection` to return `nil` for the venue session.
- Route the existing single venue request through that manager.
- Preserve status, final URL, media type, JSON parsing, and bounded retry validation.
- Add mutation-sensitive static contracts and maintained security guidance.

## Validation

- `make check`
- `make lint`
- `make test`
- `make build`
- External-directory `make -f <absolute Makefile> check`
- `sh -n scripts/check-baseline.sh`
- Seven redirect/session/request/retry/plan mutations rejected
- `git diff --check`
- Intended-file artifact and credential-shaped diff scans

## Risk

Low and localized to the Foursquare request session. A redirect now becomes a rejected non-2xx response and uses the existing delayed retry path. Apple-platform compilation and live API behavior remain unavailable on this Linux host.

## Follow-Ups

- Validate the stacked branch on the hosted macOS job.
- Keep broader Swift, CocoaPods, Alamofire, and API modernization separate.
