### PR TITLE
Bound Foursquare venue requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@
 - Reject non-finite or out-of-range venue coordinates, and reject non-finite or negative distances, before creating AR nodes or map annotations.
 - Keep credential, request, malformed-response, and empty-response retries bounded by the documented cooldown.
 - Require Foursquare venue requests to refuse redirects before forwarding credential-bearing query parameters.
+- Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout.
 - Require a 2xx Foursquare response status before JSON parsing, and keep
   rejected responses on the generic no-body-log retry path.
 - Require the exact final HTTPS Foursquare API endpoint after status validation

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 2026-06-15
 
+- Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout.
 - Refused redirects for credential-bearing Foursquare venue requests before
   URLSession can forward their query parameters.
 - Added dedicated-session, redirect-policy, request-routing, documentation, and

--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -48,6 +48,8 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
     private let foursquareSessionManager: SessionManager = {
         let configuration = URLSessionConfiguration.default
         configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
+        configuration.timeoutIntervalForRequest = 15.0
+        configuration.timeoutIntervalForResource = 30.0
         let manager = SessionManager(configuration: configuration)
         manager.delegate.taskWillPerformHTTPRedirection = { _, _, _, _ in nil }
         return manager

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ When the required SDK or runtime is unavailable, use static checks and source re
   for the exact JSON response media boundary.
 - See `docs/plans/2026-06-14-foursquare-response-final-url-validation.md` for
   the final Foursquare response URL boundary.
+- Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout.
 - See `docs/plans/2026-06-10-legacy-sdk-modernization-boundary.md` for the
   legacy SDK and dependency modernization sequence.
 - See `docs/plans/2026-06-12-hosted-project-validation.md` for the GitHub

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,6 +51,7 @@ while displaying user or debug location markers.
 Foursquare venue lookup retries should stay bounded so missing credentials,
 failed requests, or empty/malformed responses do not create immediate request
 loops while location updates continue.
+Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout.
 Credential-bearing Foursquare venue requests must refuse redirects before a
 redirect destination can receive their query parameters.
 Foursquare venue responses should require a 2xx HTTP status, an exact final

--- a/VISION.md
+++ b/VISION.md
@@ -54,6 +54,7 @@ Current baseline:
   missing, requests fail, or successful responses contain no valid venues.
 - Venue lookup refuses redirects before credentials can be forwarded to a
   redirect destination.
+- Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout.
 - Foursquare venue responses require a 2xx HTTP status before JSON parsing;
   rejected statuses use the existing generic bounded retry path.
 - Successful venue responses require the exact final HTTPS endpoint before

--- a/docs/plans/2026-06-15-foursquare-venue-request-timeouts.md
+++ b/docs/plans/2026-06-15-foursquare-venue-request-timeouts.md
@@ -1,0 +1,97 @@
+---
+title: Foursquare Venue Request Timeouts
+type: reliability
+date: 2026-06-15
+status: in_progress
+execution: code
+---
+
+# Foursquare Venue Request Timeouts
+
+## Problem Frame
+
+The dedicated Alamofire `SessionManager` rejects redirects and validates the
+final response, but its `URLSessionConfiguration` still relies on platform
+timeout defaults. A stalled venue lookup keeps `loaded` set until the request
+eventually fails, delaying the existing bounded retry release. Request and
+resource timeouts should be explicit and reviewable.
+
+## Prioritized Engineering Work
+
+1. **P0 - Request bound:** set an explicit per-request timeout before manager
+   construction.
+2. **P0 - Resource bound:** set a larger explicit total resource timeout before
+   manager construction.
+3. **P1 - Contract enforcement:** reject missing, reordered, non-positive, or
+   excessively broad timeout values through the maintained baseline.
+4. **P1 - Guidance:** document the bounds without claiming Linux runtime or
+   live Foursquare validation.
+
+## Requirements
+
+- R1. Venue requests must use a 15-second request timeout.
+- R2. The complete venue resource load must use a 30-second timeout.
+- R3. Both values must be configured before `SessionManager(configuration:)`.
+- R4. Redirect refusal, final URL validation, status/MIME checks, response
+  parsing, credential handling, and the existing 30-second retry release must
+  remain unchanged.
+- R5. Static contracts must reject timeout removal, widening, ordering drift,
+  guidance removal, and incomplete verification evidence.
+
+## Implementation Units
+
+### U1: Configure The Session
+
+Files:
+
+- `FoursquareARCamera/ViewController.swift`
+
+Approach:
+
+- Set `timeoutIntervalForRequest` to 15 seconds.
+- Set `timeoutIntervalForResource` to 30 seconds.
+- Keep both assignments adjacent to the existing headers and before manager
+  construction.
+
+### U2: Enforce The Boundary
+
+Files:
+
+- `scripts/check-venue-request-timeouts.py`
+- `scripts/check-baseline.sh`
+
+Approach:
+
+- Scope checks to the dedicated session-manager initializer.
+- Verify exact values and assignment-before-construction ordering.
+- Require completed plan evidence and maintained guidance.
+
+### U3: Synchronize Guidance
+
+Files:
+
+- `AGENTS.md`
+- `CHANGES.md`
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `docs/plans/2026-06-15-foursquare-venue-request-timeouts.md`
+
+## Verification
+
+- Focused static timeout checker and shell syntax.
+- Repository and external-directory `make check`, plus maintained alias gates.
+- Hostile mutations for request/resource removal, value widening, ordering,
+  guidance, and completion evidence.
+- Exact diff, Xcode project, generated artifact, conflict marker, and
+  changed-line secret audits.
+
+## Risks
+
+- Slow networks may fail venue lookup sooner than the platform default. The
+  existing generic failure path and 30-second retry release remain responsible
+  for recovery.
+- Xcode, simulator/device, and live Foursquare behavior cannot be established
+  on this Linux host.
+
+## Status: In Progress

--- a/docs/plans/2026-06-15-foursquare-venue-request-timeouts.md
+++ b/docs/plans/2026-06-15-foursquare-venue-request-timeouts.md
@@ -2,7 +2,7 @@
 title: Foursquare Venue Request Timeouts
 type: reliability
 date: 2026-06-15
-status: in_progress
+status: completed
 execution: code
 ---
 
@@ -94,4 +94,28 @@ Files:
 - Xcode, simulator/device, and live Foursquare behavior cannot be established
   on this Linux host.
 
-## Status: In Progress
+## Work Completed
+
+- Configured a 15-second per-request timeout and a 30-second total resource
+  timeout on the dedicated Foursquare `URLSessionConfiguration`.
+- Applied both values before constructing the Alamofire `SessionManager` and
+  preserved the existing redirect-refusal delegate.
+- Added a function-scoped static checker, baseline integration, completed plan
+  contract, and synchronized project guidance.
+
+## Verification Completed
+
+- The focused venue-timeout checker and shell syntax passed.
+- Repository and external-directory `make check`, plus `make lint`, `make test`,
+  and `make build`, passed the maintained portable baseline; each truthfully
+  reported that `xcodebuild` is unavailable on Linux.
+- Seven isolated hostile mutations were rejected: request-timeout removal,
+  resource-timeout removal, widened request timeout, widened resource timeout,
+  assignment after manager construction, guidance removal, and reopened plan
+  completion evidence.
+- Exact diff, Xcode project, workspace, generated artifact, conflict marker,
+  executable mode, and changed-line secret audits passed before delivery.
+- No simulator, physical device, signed build, or live Foursquare request was
+  executed.
+
+## Status: Completed

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -22,6 +22,8 @@ RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status
 RESPONSE_CONTENT_TYPE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-content-type-validation.md"
 RESPONSE_FINAL_URL_PLAN="$ROOT_DIR/docs/plans/2026-06-14-foursquare-response-final-url-validation.md"
 RESPONSE_REDIRECT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-foursquare-redirect-refusal.md"
+VENUE_TIMEOUT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-foursquare-venue-request-timeouts.md"
+VENUE_TIMEOUT_CHECK="$ROOT_DIR/scripts/check-venue-request-timeouts.py"
 REACHABILITY_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-reachability-exact-204.md"
 LOCATION_INDEPENDENT_MAKE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-location-independent-make.md"
 CI_WORKFLOW="$ROOT_DIR/.github/workflows/check.yml"
@@ -63,6 +65,8 @@ for path in \
   "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
   "docs/plans/2026-06-14-foursquare-response-final-url-validation.md" \
   "docs/plans/2026-06-15-foursquare-redirect-refusal.md" \
+  "docs/plans/2026-06-15-foursquare-venue-request-timeouts.md" \
+  "scripts/check-venue-request-timeouts.py" \
   "docs/plans/2026-06-13-reachability-exact-204.md" \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
@@ -74,6 +78,27 @@ for path in \
   "docs/plans/2026-06-09-foursquare-ar-mask-asset-guard.md" \
   "docs/plans/2026-06-08-foursquare-ar-camera-ios-credential-baseline.md"; do
   require_file "$path"
+done
+
+python3 "$VENUE_TIMEOUT_CHECK" "$ROOT_DIR/FoursquareARCamera/ViewController.swift"
+
+for venue_timeout_doc in AGENTS.md README.md SECURITY.md VISION.md CHANGES.md; do
+  if ! grep -Fq "Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout." "$ROOT_DIR/$venue_timeout_doc"; then
+    printf '%s\n' "$venue_timeout_doc must document bounded Foursquare venue timeouts." >&2
+    exit 1
+  fi
+done
+
+for venue_timeout_plan_contract in \
+  "status: completed" \
+  "## Status: Completed" \
+  "## Work Completed" \
+  "## Verification Completed" \
+  "hostile mutations were rejected"; do
+  if ! grep -Fq "$venue_timeout_plan_contract" "$VENUE_TIMEOUT_PLAN"; then
+    printf '%s\n' "Venue timeout plan must record completed evidence: $venue_timeout_plan_contract" >&2
+    exit 1
+  fi
 done
 
 if ! grep -Fq 'ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))' "$ROOT_DIR/Makefile" ||

--- a/scripts/check-venue-request-timeouts.py
+++ b/scripts/check-venue-request-timeouts.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+
+source = Path(sys.argv[1]).read_text(encoding="utf-8")
+start = source.find("private let foursquareSessionManager: SessionManager = {")
+end = source.find("\n    var adjustNorthByTappingSidesOfScreen", start)
+if start == -1 or end == -1:
+    raise SystemExit("Dedicated Foursquare SessionManager initializer is missing.")
+
+initializer = source[start:end]
+contracts = (
+    "let configuration = URLSessionConfiguration.default",
+    "configuration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders",
+    "configuration.timeoutIntervalForRequest = 15.0",
+    "configuration.timeoutIntervalForResource = 30.0",
+    "let manager = SessionManager(configuration: configuration)",
+    "manager.delegate.taskWillPerformHTTPRedirection = { _, _, _, _ in nil }",
+    "return manager",
+)
+for contract in contracts:
+    if initializer.count(contract) != 1:
+        raise SystemExit(f"Venue session initializer must contain one {contract!r}.")
+if not all(initializer.index(a) < initializer.index(b) for a, b in zip(contracts, contracts[1:])):
+    raise SystemExit("Venue timeout and redirect policy must precede manager publication.")
+
+print("Foursquare venue timeout checks passed.")


### PR DESCRIPTION
## Summary
- configure a 15-second request timeout and 30-second resource timeout for the dedicated Foursquare SessionManager
- apply both bounds before manager construction while preserving redirect refusal and the existing retry path
- add a scoped static checker, completed plan evidence, and synchronized reliability/security guidance

## Baseline
Venue lookup relied on implicit URLSession timeout defaults. While a request was stalled, `loaded` remained set and prevented another lookup until the platform eventually completed the request.

## Improvements
The dedicated URLSessionConfiguration now has explicit per-request and total-resource bounds before it is passed to Alamofire. Existing credentials, parameters, response validation, redirect refusal, and the 30-second retry release are unchanged.

**Engineering bar:** venue networking now has explicit, reviewable latency bounds rather than implicit platform defaults.

## Validation
- repository and external-directory `make check`
- `make lint`, `make test`, and `make build`
- seven hostile mutations rejected
- exact-path, Xcode/workspace, executable-mode, artifact, conflict, and changed-line credential audits

## Risk
- slow networks may fail venue lookup sooner than the platform default
- xcodebuild, simulator/device, signing, and live Foursquare execution were unavailable on Linux

## Follow-Ups
- require the canonical hosted macOS check on this exact head
- exercise timeout and recovery behavior on a device or simulator with a controlled delayed endpoint before release
