### PR TITLE
Execute Foursquare response URL policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,13 @@
 
 ## Coding conventions
 
-- Language mix noted in the README: Swift (16).
+- Language mix noted in the README: Swift (18).
 - Use the CocoaPods workspace when present; update `Podfile.lock` only with an intentional dependency change.
 - Preserve legacy Xcode project settings and signing assumptions unless the change is explicitly about modernization.
 
 ## Testing guidance
 
-- No dedicated test files were detected. The `lint`, `test`, and `build` targets delegate to the maintained static `make check` baseline rather than compiling or exercising app behavior.
+- `Tests/FoursquareResponseURLPolicyTests/main.swift` is a standalone behavioral harness. When `swiftc` is available, every Make gate compiles it with the production policy before running the static baseline.
 - Hosted macOS CI additionally parses the checked-in Xcode project; it does not install Pods, sign or launch the app, call live APIs, or test camera, AR, Mapbox, and location behavior.
 - Start with the narrowest relevant test or Make target, then run `make check` before handing off if the change is not documentation-only.
 - Keep README verification notes in sync when commands, fixtures, or supported toolchains change.
@@ -62,6 +62,8 @@
   rejected responses on the generic no-body-log retry path.
 - Require the exact final HTTPS Foursquare API endpoint after status validation
   and before response media validation.
+- Keep that endpoint policy in the app target and execute the same production
+  source from the standalone Swift harness.
 - Require the exact JSON response media type after status validation and before
   response handling.
 - Treat Swift, CocoaPods, Mapbox, ARKit/Core Location, and Foursquare API modernization as staged, device-verified work; update `Podfile.lock` only with an intentional dependency and CocoaPods toolchain review.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 2026-06-16
+
+- Extracted the exact Foursquare final-response endpoint predicate into app
+  production source and added a standalone Swift harness that executes the same
+  policy against accepted and hostile URLs when `swiftc` is available.
+- Extended the static baseline to require app-target membership, production
+  delegation, harness wiring, and complete endpoint-case coverage.
+
 ## 2026-06-15
 
 - Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout.

--- a/FoursquareARCamera.xcodeproj/project.pbxproj
+++ b/FoursquareARCamera.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4901EF051F1B7D560067870D /* SceneLocationEstimate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4901EF041F1B7D560067870D /* SceneLocationEstimate+Extensions.swift */; };
 		49099E391F24BAE5007B76FD /* SCNVector3+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49099E381F24BAE5007B76FD /* SCNVector3+Extensions.swift */; };
+		A16061611F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16061621F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift */; };
 		49A3FBDC1F09988100AA59C8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A3FBDB1F09988100AA59C8 /* AppDelegate.swift */; };
 		49A3FBE01F09988100AA59C8 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A3FBDF1F09988100AA59C8 /* ViewController.swift */; };
 		49A3FBE81F09988100AA59C8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49A3FBE61F09988100AA59C8 /* LaunchScreen.storyboard */; };
@@ -32,6 +33,7 @@
 		359749B04AFDD68C056A44D3 /* Pods-FoursquareARCamera.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FoursquareARCamera.debug.xcconfig"; path = "Pods/Target Support Files/Pods-FoursquareARCamera/Pods-FoursquareARCamera.debug.xcconfig"; sourceTree = "<group>"; };
 		4901EF041F1B7D560067870D /* SceneLocationEstimate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SceneLocationEstimate+Extensions.swift"; sourceTree = "<group>"; };
 		49099E381F24BAE5007B76FD /* SCNVector3+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SCNVector3+Extensions.swift"; sourceTree = "<group>"; };
+		A16061621F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareResponseURLPolicy.swift; sourceTree = "<group>"; };
 		49A3FBD81F09988100AA59C8 /* FoursquareARCamera.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FoursquareARCamera.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		49A3FBDB1F09988100AA59C8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		49A3FBDF1F09988100AA59C8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 		49A3FBF31F099A4A00AA59C8 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				A16061621F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift */,
 				C3452AED1F30E8F300389E0A /* Assets.xcassets */,
 				C3452AE91F2FBD3700389E0A /* Views */,
 				49A3FBF61F099C8100AA59C8 /* SceneLocationView.swift */,
@@ -287,6 +290,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A16061611F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift in Sources */,
 				49099E391F24BAE5007B76FD /* SCNVector3+Extensions.swift in Sources */,
 				C3452AE81F2FBD2600389E0A /* FSQView.swift in Sources */,
 				49A3FBF71F099C8100AA59C8 /* SceneLocationView.swift in Sources */,

--- a/FoursquareARCamera/Source/FoursquareResponseURLPolicy.swift
+++ b/FoursquareARCamera/Source/FoursquareResponseURLPolicy.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum FoursquareResponseURLPolicy {
+    static func accepts(_ url: URL?) -> Bool {
+        guard let url = url,
+            let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return false
+        }
+
+        return components.scheme == "https" &&
+            components.host == "api.foursquare.com" &&
+            components.user == nil &&
+            components.password == nil &&
+            components.port == nil &&
+            components.percentEncodedPath == "/v2/venues/search" &&
+            components.fragment == nil
+    }
+}

--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -205,15 +205,7 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
             self.foursquareSessionManager.request("https://api.foursquare.com/v2/venues/search", parameters: parameters)
                 .validate(statusCode: 200..<300)
                 .validate { _, response, _ in
-                    guard let finalURL = response.url,
-                        let components = URLComponents(url: finalURL, resolvingAgainstBaseURL: false),
-                        components.scheme == "https",
-                        components.host == "api.foursquare.com",
-                        components.user == nil,
-                        components.password == nil,
-                        components.port == nil,
-                        components.percentEncodedPath == "/v2/venues/search",
-                        components.fragment == nil else {
+                    guard FoursquareResponseURLPolicy.accepts(response.url) else {
                         return .failure(NSError(domain: "FoursquareResponseValidation", code: 1, userInfo: nil))
                     }
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
 .PHONY: build check lint test
 
+SWIFTC ?= swiftc
 ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 lint test build: check
 
 check:
+	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-foursquare-response-url-tests.sh"; \
+	else \
+		echo "swiftc unavailable; executable Foursquare response URL tests skipped"; \
+	fi
 	@"$(ROOT)/scripts/check-baseline.sh"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 `garethpaul/foursquare-ar-camera-ios` is an Apple platform application or Swift sample. AR Camera using Foursquare API. 
 
-This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (16).
+This README is based on the checked-in source, manifests, scripts, and repository metadata on the `master` branch. The project language mix found during review was: Swift (18).
 
 ## Repository Contents
 
@@ -27,7 +27,7 @@ Additional scan context:
 - Source directories: FoursquareARCamera
 - Dependency and build manifests: Podfile, Podfile.lock
 - Entry points or build surfaces: FoursquareARCamera.xcworkspace, FoursquareARCamera.xcodeproj
-- Test-looking files: no obvious test files detected
+- Test-looking files: one standalone Swift behavioral harness under `Tests/`
 
 ## Getting Started
 
@@ -70,7 +70,7 @@ the workspace for functional builds only after generating Pods locally.
 
 ## Testing and Verification
 
-Run the static baseline:
+Run the maintained baseline:
 
 ```bash
 make lint
@@ -83,9 +83,10 @@ Use the absolute Makefile path to run the same gates from another working
 directory. Verification resolves the checker relative to the loaded Makefile
 rather than the caller's directory.
 
-The `lint`, `test`, and `build` targets currently delegate to the static
-baseline so the repository has a consistent local gate even when Xcode is not
-installed. The baseline verifies that credentials are build settings, tracked
+The `lint`, `test`, and `build` targets delegate to the same baseline. When
+`swiftc` is available, each gate compiles and runs the production Foursquare
+response URL policy against accepted and hostile endpoints before the static
+contracts. The baseline also verifies that credentials are build settings, tracked
 machine artifacts are absent, location logs avoid detailed coordinates, and the
 venue mask asset is not force-unwrapped. The workspace can be listed when
 `xcodebuild` is installed. The venue tap interaction guard keeps one tap
@@ -106,7 +107,8 @@ validates a 2xx HTTP status and the final HTTPS
 api.foursquare.com endpoint and exact path. It also requires the exact
 application/json response media type before JSON response parsing; rejected
 responses use the same generic bounded retry path without logging response
-data.
+data. The final URL decision is shared with the standalone executable harness,
+so the tested predicate is the same source compiled into the app target.
 Venue responses also require finite latitude/longitude within geographic bounds
 and a finite nonnegative distance before rendering.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,9 @@ response URL at the HTTPS `api.foursquare.com/v2/venues/search` endpoint, and
 the exact `application/json` response media type before JSON parsing; rejected
 responses must use the generic retry path without logging bodies, credentials,
 request URLs, redirect targets, or location details.
+The final-response URL predicate is compiled into the app target and is also
+executed by the standalone Swift harness, keeping security checks tied to the
+production decision rather than a duplicated test implementation.
 Foursquare venue coordinates should be finite and geographically bounded, and
 distance values should be finite and nonnegative before AR or map rendering.
 

--- a/Tests/FoursquareResponseURLPolicyTests/main.swift
+++ b/Tests/FoursquareResponseURLPolicyTests/main.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+private var failureCount = 0
+
+private func expect(_ urlString: String?, accepted expected: Bool, _ message: String) {
+    let url: URL?
+    if let urlString = urlString {
+        url = URL(string: urlString)
+    } else {
+        url = nil
+    }
+    let actual = FoursquareResponseURLPolicy.accepts(url)
+    if actual != expected {
+        failureCount += 1
+        print("FAIL: \(message): expected \(expected), got \(actual)")
+    }
+}
+
+expect("https://api.foursquare.com/v2/venues/search", accepted: true, "exact endpoint")
+expect("https://api.foursquare.com/v2/venues/search?ll=1,2", accepted: true, "query parameters")
+expect(nil, accepted: false, "missing URL")
+expect("http://api.foursquare.com/v2/venues/search", accepted: false, "non-HTTPS scheme")
+expect("https://www.foursquare.com/v2/venues/search", accepted: false, "wrong host")
+expect("https://api.foursquare.com.example/v2/venues/search", accepted: false, "host suffix")
+expect("https://user@api.foursquare.com/v2/venues/search", accepted: false, "userinfo")
+expect("https://user:password@api.foursquare.com/v2/venues/search", accepted: false, "password")
+expect("https://api.foursquare.com:443/v2/venues/search", accepted: false, "explicit port")
+expect("https://api.foursquare.com/v2/venues/search/", accepted: false, "trailing slash")
+expect("https://api.foursquare.com/v2/venues/%73earch", accepted: false, "encoded path")
+expect("https://api.foursquare.com/v2/venues/search#fragment", accepted: false, "fragment")
+
+if failureCount > 0 {
+    exit(1)
+}
+
+print("FoursquareResponseURLPolicy behavioral tests passed")

--- a/VISION.md
+++ b/VISION.md
@@ -59,6 +59,8 @@ Current baseline:
   rejected statuses use the existing generic bounded retry path.
 - Successful venue responses require the exact final HTTPS endpoint before
   media validation or response handling.
+- The exact endpoint predicate is shared by the app target and an executable
+  standalone Swift behavioral harness.
 - Successful venue responses require the exact JSON response media type before
   response handling.
 - Venue response coordinates and distances are finite and range-checked before

--- a/docs/plans/2026-06-16-executable-foursquare-response-url-tests.md
+++ b/docs/plans/2026-06-16-executable-foursquare-response-url-tests.md
@@ -1,0 +1,52 @@
+---
+title: Execute the Foursquare final-response URL policy
+status: completed
+date: 2026-06-16
+---
+
+# Execute the Foursquare final-response URL policy
+
+## Goal
+
+Compile and execute the same deterministic final-response URL predicate used by
+the app, without requiring CocoaPods, credentials, a live request, or a device.
+
+## Requirements
+
+- Keep one Foundation-only policy in app production source and the Xcode app
+  target.
+- Delegate the Alamofire final-response validator to that policy without
+  changing status, media, retry, redirect, credential, or parsing behavior.
+- Compile the production policy with a standalone Swift harness from every Make
+  gate when `swiftc` is available.
+- Accept the exact HTTPS endpoint with or without query parameters and reject a
+  missing URL, wrong scheme or host, host suffixes, userinfo, passwords,
+  explicit ports, path drift, encoded-path drift, and fragments.
+- Preserve explicit platform limitations: Linux static validation does not
+  establish Xcode compilation, device behavior, or live Foursquare behavior.
+
+## Work Completed
+
+- Extracted `FoursquareResponseURLPolicy` from the compiled view-controller
+  request chain and added it to the Xcode app target.
+- Added a standalone Swift harness and bounded temporary-build runner.
+- Wired the runner into all Make aliases before the maintained static baseline.
+- Extended static contracts for production delegation, app-target membership,
+  executable wiring, endpoint cases, documentation, and completed evidence.
+
+## Verification Completed
+
+- all four Make gates passed from the repository root.
+- The absolute Makefile path passed from an external directory.
+- The production policy mutation failed after weakening an endpoint constraint.
+- The app delegation mutation failed after bypassing the production policy.
+- The Xcode target membership mutation failed after removing the policy source.
+- The accepted endpoint mutation failed after removing a permitted case.
+- The hostile endpoint mutation failed after removing a rejected case.
+- The plan evidence mutation failed after removing completed verification text.
+- Shell syntax, project parsing, diff checks, intended-file artifact checks, and
+  secret-pattern scans passed.
+- `swiftc` and Xcode are unavailable on this Linux host, so local gates verify
+  deterministic source wiring and defer execution to the hosted macOS runner.
+- The hosted pull-request check is recorded against the exact pushed head in
+  the external engineering tracker.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -21,6 +21,7 @@ COCOALUMBERJACK_PIN_PLAN="$ROOT_DIR/docs/plans/2026-06-13-cocoalumberjack-commit
 RESPONSE_STATUS_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-status-validation.md"
 RESPONSE_CONTENT_TYPE_PLAN="$ROOT_DIR/docs/plans/2026-06-13-foursquare-response-content-type-validation.md"
 RESPONSE_FINAL_URL_PLAN="$ROOT_DIR/docs/plans/2026-06-14-foursquare-response-final-url-validation.md"
+RESPONSE_URL_TEST_PLAN="$ROOT_DIR/docs/plans/2026-06-16-executable-foursquare-response-url-tests.md"
 RESPONSE_REDIRECT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-foursquare-redirect-refusal.md"
 VENUE_TIMEOUT_PLAN="$ROOT_DIR/docs/plans/2026-06-15-foursquare-venue-request-timeouts.md"
 VENUE_TIMEOUT_CHECK="$ROOT_DIR/scripts/check-venue-request-timeouts.py"
@@ -50,6 +51,7 @@ for path in \
   "FoursquareARCamera.xcodeproj/project.pbxproj" \
   "FoursquareARCamera/Info.plist" \
   "FoursquareARCamera/ViewController.swift" \
+  "FoursquareARCamera/Source/FoursquareResponseURLPolicy.swift" \
   "FoursquareARCamera/Source/Helpers/LocationManager.swift" \
   "FoursquareARCamera/Source/Reachability.swift" \
   "FoursquareARCamera/Source/Views/FSQView.swift" \
@@ -64,9 +66,12 @@ for path in \
   "docs/plans/2026-06-13-foursquare-response-status-validation.md" \
   "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
   "docs/plans/2026-06-14-foursquare-response-final-url-validation.md" \
+  "docs/plans/2026-06-16-executable-foursquare-response-url-tests.md" \
   "docs/plans/2026-06-15-foursquare-redirect-refusal.md" \
   "docs/plans/2026-06-15-foursquare-venue-request-timeouts.md" \
   "scripts/check-venue-request-timeouts.py" \
+  "scripts/run-foursquare-response-url-tests.sh" \
+  "Tests/FoursquareResponseURLPolicyTests/main.swift" \
   "docs/plans/2026-06-13-reachability-exact-204.md" \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
@@ -185,11 +190,12 @@ if ! grep -Fq 'configuredValue("FoursquareClientID")' "$view" ||
   exit 1
 fi
 
-python3 - "$view" <<'PY'
+python3 - "$view" "$ROOT_DIR/FoursquareARCamera/Source/FoursquareResponseURLPolicy.swift" <<'PY'
 import sys
 from pathlib import Path
 
 source = Path(sys.argv[1]).read_text()
+policy = Path(sys.argv[2]).read_text()
 lookup = source.split("func getFoursquareLocations", 1)[-1].split("\n    @objc", 1)[0]
 manager_contract = (
     "private let foursquareSessionManager: SessionManager = {",
@@ -215,6 +221,11 @@ if any(lookup.count(fragment) != 1 for fragment in contract):
 if -1 in positions or positions != sorted(positions) or len(set(positions)) != len(positions):
     raise SystemExit("Foursquare status, final URL, and JSON media validation must run before response handling.")
 final_url_contract = (
+    "FoursquareResponseURLPolicy.accepts(response.url)",
+    'NSError(domain: "FoursquareResponseValidation", code: 1, userInfo: nil)',
+)
+policy_contract = (
+    "static func accepts(_ url: URL?) -> Bool",
     'components.scheme == "https"',
     'components.host == "api.foursquare.com"',
     "components.user == nil",
@@ -222,12 +233,53 @@ final_url_contract = (
     "components.port == nil",
     'components.percentEncodedPath == "/v2/venues/search"',
     "components.fragment == nil",
-    'NSError(domain: "FoursquareResponseValidation", code: 1, userInfo: nil)',
 )
 if any(lookup.count(fragment) != 1 for fragment in final_url_contract):
+    raise SystemExit("Foursquare final response validation must delegate once to the executable endpoint policy.")
+if any(policy.count(fragment) != 1 for fragment in policy_contract):
     raise SystemExit("Foursquare final response URL validation must preserve the exact HTTPS endpoint boundary.")
 if lookup.count("case .failure:") != 1 or lookup.count(failure) != 1:
     raise SystemExit("Rejected Foursquare responses must retain the bounded generic failure retry.")
+PY
+
+python3 - "$ROOT_DIR/FoursquareARCamera.xcodeproj/project.pbxproj" \
+  "$ROOT_DIR/Makefile" \
+  "$ROOT_DIR/scripts/run-foursquare-response-url-tests.sh" \
+  "$ROOT_DIR/Tests/FoursquareResponseURLPolicyTests/main.swift" <<'PY'
+import sys
+from pathlib import Path
+
+project, makefile, runner, tests = (Path(path).read_text() for path in sys.argv[1:])
+if project.count("FoursquareResponseURLPolicy.swift in Sources") != 2:
+    raise SystemExit("The executable Foursquare response URL policy must belong to the app target once.")
+if project.count("/* FoursquareResponseURLPolicy.swift */") != 3:
+    raise SystemExit("The Foursquare response URL policy project reference must remain complete and unique.")
+if makefile.count('scripts/run-foursquare-response-url-tests.sh') != 1:
+    raise SystemExit("Every Make gate must invoke the executable Foursquare response URL tests once.")
+runner_contract = (
+    "FoursquareARCamera/Source/FoursquareResponseURLPolicy.swift",
+    "Tests/FoursquareResponseURLPolicyTests/main.swift",
+    'mktemp -d "${TMPDIR:-/tmp}/foursquare-response-url-tests.XXXXXX"',
+    "trap cleanup 0",
+)
+if any(runner.count(fragment) != 1 for fragment in runner_contract):
+    raise SystemExit("The Foursquare response URL test runner must compile production policy with bounded cleanup.")
+test_contract = (
+    'accepted: true, "exact endpoint"',
+    'accepted: true, "query parameters"',
+    'accepted: false, "missing URL"',
+    'accepted: false, "non-HTTPS scheme"',
+    'accepted: false, "wrong host"',
+    'accepted: false, "host suffix"',
+    'accepted: false, "userinfo"',
+    'accepted: false, "password"',
+    'accepted: false, "explicit port"',
+    'accepted: false, "trailing slash"',
+    'accepted: false, "encoded path"',
+    'accepted: false, "fragment"',
+)
+if any(tests.count(fragment) != 1 for fragment in test_contract):
+    raise SystemExit("Executable response URL tests must preserve every accepted and hostile endpoint case.")
 PY
 
 if ! grep -Fq "refuses redirects before sending venue query credentials" "$ROOT_DIR/README.md" ||
@@ -863,6 +915,37 @@ if (
 ):
     raise SystemExit(
         "Foursquare response final URL plan must remain completed with actual verification recorded."
+    )
+PY
+
+python3 - "$RESPONSE_URL_TEST_PLAN" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+plan = Path(sys.argv[1]).read_text()
+frontmatter = plan.split("---", 2)[1]
+statuses = re.findall(r"^status: .+$", frontmatter, flags=re.MULTILINE)
+verification = plan.split("## Verification Completed\n", 1)[-1]
+required = (
+    "all four Make gates passed",
+    "absolute Makefile path passed",
+    "production policy mutation failed",
+    "app delegation mutation failed",
+    "Xcode target membership mutation failed",
+    "accepted endpoint mutation failed",
+    "hostile endpoint mutation failed",
+    "plan evidence mutation failed",
+    "hosted pull-request check",
+)
+if (
+    statuses != ["status: completed"]
+    or "## Verification Completed\n" not in plan
+    or any(item not in verification for item in required)
+    or re.search(r"\b(?:pending|todo|tbd|not run|not yet)\b", verification, re.IGNORECASE)
+):
+    raise SystemExit(
+        "Executable Foursquare response URL test plan must remain completed with actual verification recorded."
     )
 PY
 

--- a/scripts/run-foursquare-response-url-tests.sh
+++ b/scripts/run-foursquare-response-url-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SWIFTC=${SWIFTC:-swiftc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/foursquare-response-url-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$SWIFTC" \
+    "$ROOT/FoursquareARCamera/Source/FoursquareResponseURLPolicy.swift" \
+    "$ROOT/Tests/FoursquareResponseURLPolicyTests/main.swift" \
+    -o "$BUILD_DIR/foursquare-response-url-tests"
+
+"$BUILD_DIR/foursquare-response-url-tests"


### PR DESCRIPTION
## Summary
- extract the exact final-response endpoint predicate into Foundation-only app production source
- execute that same policy from a standalone Swift harness on macOS-hosted Make gates
- preserve the existing Alamofire status, media, redirect, retry, credential, and response-handling behavior

## Baseline
The final Foursquare response URL boundary was enforced only through inline production code and static source-shape mutations. That verified the contract text but did not execute the deterministic predicate against accepted and hostile URLs.

## Improvements
`FoursquareResponseURLPolicy` is now compiled into the app target and called by the existing Alamofire validator. The standalone harness compiles that same source and covers the exact endpoint, permitted query parameters, missing URLs, wrong schemes and hosts, host suffixes, userinfo, passwords, explicit ports, path drift, encoded paths, and fragments.

**Engineering bar:** the security-sensitive final endpoint decision now has executable production-code coverage instead of only static source assertions.

## Validation
- `make check`, `make lint`, `make test`, and `make build`
- absolute-Makefile `make check` from `/tmp`
- six hostile checker mutations rejected
- shell syntax, Xcode project membership, executable mode, diff, artifact, and changed-line credential scans
- local `swiftc` and Xcode were unavailable; executable Swift and project parsing are delegated to the bounded macOS hosted check

## Risk
- this preserves the existing exact URL policy, but changes its location and Xcode project membership
- the standalone harness does not install Pods, launch the app, call Foursquare, or replace simulator/device validation

## Follow-Ups
- record the canonical hosted macOS result against commit `447c97c7d58dc2112c02940b57a0eb830b5a94fb`
- exercise the full Alamofire response chain with controlled redirects and malformed responses during a future compatible Xcode/device validation pass

