### PR TITLE
fix: bound venue distance conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@
 - Keep Core Location updates gated on authorization before starting AR venue lookup behavior.
 - Keep location manager setup and heading forwarding resilient when optional Core Location state is unavailable.
 - Reject non-finite or out-of-range venue coordinates, and reject non-finite or negative distances, before creating AR nodes or map annotations.
+- Keep venue distance-to-feet conversion within Int bounds before rendering.
 - Keep credential, request, malformed-response, and empty-response retries bounded by the documented cooldown.
 - Require Foursquare venue requests to refuse redirects before forwarding credential-bearing query parameters.
 - Foursquare venue networking uses a 15-second request timeout and a 30-second resource timeout.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2026-06-17
+
+- Bound venue distance conversion before integer rendering and added an
+  executable Swift policy harness for normal and hostile values.
+
 ## 2026-06-16
 
 - Extracted the exact Foursquare final-response endpoint predicate into app

--- a/FoursquareARCamera.xcodeproj/project.pbxproj
+++ b/FoursquareARCamera.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4901EF051F1B7D560067870D /* SceneLocationEstimate+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4901EF041F1B7D560067870D /* SceneLocationEstimate+Extensions.swift */; };
 		49099E391F24BAE5007B76FD /* SCNVector3+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49099E381F24BAE5007B76FD /* SCNVector3+Extensions.swift */; };
 		A16061611F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A16061621F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift */; };
+		A17061711F24BAE5007B76FD /* FoursquareVenueDistancePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17061721F24BAE5007B76FD /* FoursquareVenueDistancePolicy.swift */; };
 		49A3FBDC1F09988100AA59C8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A3FBDB1F09988100AA59C8 /* AppDelegate.swift */; };
 		49A3FBE01F09988100AA59C8 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A3FBDF1F09988100AA59C8 /* ViewController.swift */; };
 		49A3FBE81F09988100AA59C8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49A3FBE61F09988100AA59C8 /* LaunchScreen.storyboard */; };
@@ -34,6 +35,7 @@
 		4901EF041F1B7D560067870D /* SceneLocationEstimate+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SceneLocationEstimate+Extensions.swift"; sourceTree = "<group>"; };
 		49099E381F24BAE5007B76FD /* SCNVector3+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SCNVector3+Extensions.swift"; sourceTree = "<group>"; };
 		A16061621F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareResponseURLPolicy.swift; sourceTree = "<group>"; };
+		A17061721F24BAE5007B76FD /* FoursquareVenueDistancePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoursquareVenueDistancePolicy.swift; sourceTree = "<group>"; };
 		49A3FBD81F09988100AA59C8 /* FoursquareARCamera.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FoursquareARCamera.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		49A3FBDB1F09988100AA59C8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		49A3FBDF1F09988100AA59C8 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 			isa = PBXGroup;
 			children = (
 				A16061621F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift */,
+				A17061721F24BAE5007B76FD /* FoursquareVenueDistancePolicy.swift */,
 				C3452AED1F30E8F300389E0A /* Assets.xcassets */,
 				C3452AE91F2FBD3700389E0A /* Views */,
 				49A3FBF61F099C8100AA59C8 /* SceneLocationView.swift */,
@@ -291,6 +294,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A16061611F24BAE5007B76FD /* FoursquareResponseURLPolicy.swift in Sources */,
+				A17061711F24BAE5007B76FD /* FoursquareVenueDistancePolicy.swift in Sources */,
 				49099E391F24BAE5007B76FD /* SCNVector3+Extensions.swift in Sources */,
 				C3452AE81F2FBD2600389E0A /* FSQView.swift in Sources */,
 				49A3FBF71F099C8100AA59C8 /* SceneLocationView.swift in Sources */,

--- a/FoursquareARCamera/Source/FoursquareVenueDistancePolicy.swift
+++ b/FoursquareARCamera/Source/FoursquareVenueDistancePolicy.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum FoursquareVenueDistancePolicy {
+    private static let feetPerMeter = 3.28084
+    static let maximumConvertibleMeters =
+        (Double(Int.max).nextDown / feetPerMeter).nextDown
+
+    static func feet(fromMeters distance: Double) -> Int? {
+        guard distance.isFinite,
+            distance >= 0,
+            distance <= maximumConvertibleMeters else {
+            return nil
+        }
+
+        return Int(distance * feetPerMeter)
+    }
+}

--- a/FoursquareARCamera/ViewController.swift
+++ b/FoursquareARCamera/ViewController.swift
@@ -230,19 +230,21 @@ class ViewController: UIViewController, MKMapViewDelegate, MGLMapViewDelegate, S
                             venueLongitude.isFinite,
                             (-180.0...180.0).contains(venueLongitude),
                             distance.isFinite,
-                            distance >= 0 else {
+                            distance >= 0,
+                            let distanceFeet = FoursquareVenueDistancePolicy.feet(
+                                fromMeters: distance
+                            ) else {
                             DDLogWarn("Skipping malformed Foursquare venue response.")
                             continue
                         }
 
                         let categoryName = venue.1["categories"].array?.first?["name"].string ?? "Venue"
-                        let ratingStr = Int(distance * 3.28084)
                         
                         let frameSize = CGRect(x: 0, y: 0, width: 362, height: 291)
                         let fsview = FSQView(frame: frameSize)
                         fsview.venueName.text = name
                         fsview.categoryName.text = categoryName
-                        fsview.ratingStr.text = "\(ratingStr)ft"
+                        fsview.ratingStr.text = "\(distanceFeet)ft"
                         
                         var image = UIImage.imageWithView(view: fsview)
                         

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ lint test build: check
 check:
 	@if command -v "$(SWIFTC)" >/dev/null 2>&1; then \
 		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-foursquare-response-url-tests.sh"; \
+		SWIFTC="$(SWIFTC)" "$(ROOT)/scripts/run-foursquare-venue-distance-tests.sh"; \
 	else \
-		echo "swiftc unavailable; executable Foursquare response URL tests skipped"; \
+		echo "swiftc unavailable; executable Foursquare policy tests skipped"; \
 	fi
 	@"$(ROOT)/scripts/check-baseline.sh"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ responses use the same generic bounded retry path without logging response
 data. The final URL decision is shared with the standalone executable harness,
 so the tested predicate is the same source compiled into the app target.
 Venue responses also require finite latitude/longitude within geographic bounds
-and a finite nonnegative distance before rendering.
+and a finite nonnegative distance whose integer-foot conversion is bounded
+before rendering.
 
 GitHub Actions runs `make check` on a bounded `macos-15` job for pushes and pull
 requests. The checkout action is immutably pinned with read-only repository

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,7 +63,8 @@ The final-response URL predicate is compiled into the app target and is also
 executed by the standalone Swift harness, keeping security checks tied to the
 production decision rather than a duplicated test implementation.
 Foursquare venue coordinates should be finite and geographically bounded, and
-distance values should be finite and nonnegative before AR or map rendering.
+distance values should be finite and nonnegative before AR or map rendering;
+their integer conversion must remain bounded to avoid malformed-response traps.
 
 GitHub Actions runs the credential-free static and Xcode project baseline with
 read-only repository permissions, an immutable checkout pin, a bounded macOS

--- a/Tests/FoursquareVenueDistancePolicyTests/main.swift
+++ b/Tests/FoursquareVenueDistancePolicyTests/main.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+private var failureCount = 0
+
+private func expect(_ meters: Double, feet expected: Int?, _ message: String) {
+    let actual = FoursquareVenueDistancePolicy.feet(fromMeters: meters)
+    if actual != expected {
+        failureCount += 1
+        print("FAIL: \(message): expected \(String(describing: expected)), got \(String(describing: actual))")
+    }
+}
+
+expect(0, feet: 0, "zero")
+expect(1, feet: 3, "one meter truncates to integer feet")
+expect(200, feet: 656, "ordinary venue radius")
+
+let maximumMeters = FoursquareVenueDistancePolicy.maximumConvertibleMeters
+if FoursquareVenueDistancePolicy.feet(fromMeters: maximumMeters) == nil {
+    failureCount += 1
+    print("FAIL: maximum convertible distance must be accepted")
+}
+
+expect(maximumMeters.nextUp, feet: nil, "distance above conversion boundary")
+expect(-1, feet: nil, "negative distance")
+expect(Double.nan, feet: nil, "NaN distance")
+expect(Double.infinity, feet: nil, "positive infinity")
+expect(-Double.infinity, feet: nil, "negative infinity")
+
+if failureCount > 0 {
+    exit(1)
+}
+
+print("FoursquareVenueDistancePolicy behavioral tests passed")

--- a/VISION.md
+++ b/VISION.md
@@ -65,6 +65,7 @@ Current baseline:
   response handling.
 - Venue response coordinates and distances are finite and range-checked before
   AR nodes or map annotations are created.
+- Bound venue distance conversion before integer rendering.
 - The local Makefile exposes lint, test, build, and check targets for a stable
   pre-push gate.
 - GitHub Actions runs the same gate on a bounded macOS job with read-only

--- a/docs/plans/2026-06-17-foursquare-venue-distance-boundary.md
+++ b/docs/plans/2026-06-17-foursquare-venue-distance-boundary.md
@@ -1,7 +1,7 @@
 ---
 title: Foursquare Venue Distance Boundary
 type: bugfix
-status: planned
+status: pending_hosted_verification
 date: 2026-06-17
 ---
 
@@ -91,4 +91,22 @@ Mapbox rotation boundary without exposing its value.
 
 ## Verification Results
 
-Implementation and verification are pending.
+Implementation is complete. The production parser delegates meters-to-feet
+conversion to the new Foundation-only policy, and the helper is a member of the
+app target. The standalone harness covers zero, ordinary values, the maximum
+accepted value, overflow, negative values, NaN, and both infinities.
+
+Repository-root and external-directory `make check` passed on Linux. The gate
+truthfully skipped executable Swift tests and Xcode project parsing because
+`swiftc` and `xcodebuild` are unavailable; shell syntax, static source wiring,
+project membership, workflow wiring, and maintained guidance passed.
+
+Eight isolated mutations were rejected across the conversion bound,
+production delegation, boundary cases, Xcode membership, Make wiring,
+maintained guidance, and plan status.
+
+The validation was offline and no live Foursquare request was made. The
+historical Mapbox secret-scanning alert remains an external rotation or
+revocation boundary; no secret value was read, copied, or recorded.
+
+Exact-head hosted checks remain pending.

--- a/docs/plans/2026-06-17-foursquare-venue-distance-boundary.md
+++ b/docs/plans/2026-06-17-foursquare-venue-distance-boundary.md
@@ -1,0 +1,94 @@
+---
+title: Foursquare Venue Distance Boundary
+type: bugfix
+status: planned
+date: 2026-06-17
+---
+
+# Foursquare Venue Distance Boundary
+
+## Context
+
+The venue parser accepts every finite nonnegative distance and then converts
+meters to integer feet. A malformed but finite value can overflow the integer
+conversion and terminate the app before the venue is skipped.
+
+## Priority
+
+1. Make the meters-to-feet conversion total for untrusted venue data.
+2. Keep normal Foursquare distances and the current integer-foot display.
+3. Execute the production policy in the hosted macOS gate.
+
+## Requirements
+
+- Add a small Foundation-only production policy that returns integer feet only
+  for finite, nonnegative values whose converted result fits in `Int`.
+- Use the policy from `FoursquareARCamera/ViewController.swift` before rendering
+  a venue.
+- Add standalone Swift behavior coverage for zero, ordinary values, the largest
+  accepted value, overflow, negative values, NaN, and infinities.
+- Wire the executable policy tests into `make check` and the canonical hosted
+  workflow without requiring credentials or a live Foursquare request.
+- Add mutation-sensitive static contracts and update maintained guidance.
+
+## Implementation Units
+
+### 1. Production conversion policy
+
+Files:
+
+- `FoursquareARCamera/Source/FoursquareVenueDistancePolicy.swift`
+- `FoursquareARCamera/ViewController.swift`
+- `FoursquareARCamera.xcodeproj/project.pbxproj`
+
+Centralize safe conversion and make malformed distances follow the existing
+skip-and-log path.
+
+### 2. Executable and static regressions
+
+Files:
+
+- `Tests/FoursquareVenueDistancePolicyTests/main.swift`
+- `scripts/run-foursquare-venue-distance-tests.sh`
+- `scripts/check-baseline.sh`
+- `.github/workflows/check.yml`
+- `Makefile`
+
+Compile the actual production helper with the standalone harness on macOS and
+preserve portable static validation on Linux.
+
+### 3. Guidance and evidence
+
+Files:
+
+- `README.md`
+- `SECURITY.md`
+- `VISION.md`
+- `CHANGES.md`
+- `AGENTS.md`
+- `docs/plans/2026-06-17-foursquare-venue-distance-boundary.md`
+
+Record only executed local and hosted evidence and preserve the historical
+Mapbox rotation boundary without exposing its value.
+
+## Validation
+
+- Run the executable Swift policy tests where `swiftc` is available.
+- Run repository-root and external-directory `make check`.
+- Reject isolated mutations for production wiring, conversion bounds, behavior
+  cases, workflow wiring, maintained guidance, and plan evidence.
+- Audit the exact diff, project-file membership, generated artifacts,
+  whitespace, conflict markers, and credential-shaped additions.
+- Require exact-head hosted checks before recording terminal hosted evidence.
+
+## Scope Boundaries
+
+- Do not invent a tighter Foursquare business-distance limit.
+- Do not make a live Foursquare request or require API credentials.
+- Do not expose, copy, resolve, or close historical secret-scanning alert data.
+- Do not merge or close this stacked pull request or its predecessors without
+  explicit authorization.
+
+## Verification Results
+
+Implementation and verification are pending.

--- a/docs/plans/2026-06-17-foursquare-venue-distance-boundary.md
+++ b/docs/plans/2026-06-17-foursquare-venue-distance-boundary.md
@@ -1,7 +1,7 @@
 ---
 title: Foursquare Venue Distance Boundary
 type: bugfix
-status: pending_hosted_verification
+status: completed
 date: 2026-06-17
 ---
 
@@ -109,4 +109,7 @@ The validation was offline and no live Foursquare request was made. The
 historical Mapbox secret-scanning alert remains an external rotation or
 revocation boundary; no secret value was read, copied, or recorded.
 
-Exact-head hosted checks remain pending.
+Both exact-head push and pull-request checks passed at implementation commit
+`0b540e158042063e06b4a7a822aee7d2b53497c3`. Push run `27673872489` and
+pull-request run `27673883985` executed the production venue-distance policy
+successfully on hosted macOS.

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -52,6 +52,7 @@ for path in \
   "FoursquareARCamera/Info.plist" \
   "FoursquareARCamera/ViewController.swift" \
   "FoursquareARCamera/Source/FoursquareResponseURLPolicy.swift" \
+  "FoursquareARCamera/Source/FoursquareVenueDistancePolicy.swift" \
   "FoursquareARCamera/Source/Helpers/LocationManager.swift" \
   "FoursquareARCamera/Source/Reachability.swift" \
   "FoursquareARCamera/Source/Views/FSQView.swift" \
@@ -67,11 +68,14 @@ for path in \
   "docs/plans/2026-06-13-foursquare-response-content-type-validation.md" \
   "docs/plans/2026-06-14-foursquare-response-final-url-validation.md" \
   "docs/plans/2026-06-16-executable-foursquare-response-url-tests.md" \
+  "docs/plans/2026-06-17-foursquare-venue-distance-boundary.md" \
   "docs/plans/2026-06-15-foursquare-redirect-refusal.md" \
   "docs/plans/2026-06-15-foursquare-venue-request-timeouts.md" \
   "scripts/check-venue-request-timeouts.py" \
   "scripts/run-foursquare-response-url-tests.sh" \
+  "scripts/run-foursquare-venue-distance-tests.sh" \
   "Tests/FoursquareResponseURLPolicyTests/main.swift" \
+  "Tests/FoursquareVenueDistancePolicyTests/main.swift" \
   "docs/plans/2026-06-13-reachability-exact-204.md" \
   "docs/plans/2026-06-13-location-independent-make.md" \
   "docs/plans/2026-06-09-fsq-view-nib-outlet-guard.md" \
@@ -948,6 +952,75 @@ if (
         "Executable Foursquare response URL test plan must remain completed with actual verification recorded."
     )
 PY
+
+python3 - \
+  "$ROOT_DIR/FoursquareARCamera/ViewController.swift" \
+  "$ROOT_DIR/FoursquareARCamera/Source/FoursquareVenueDistancePolicy.swift" \
+  "$ROOT_DIR/Tests/FoursquareVenueDistancePolicyTests/main.swift" \
+  "$ROOT_DIR/FoursquareARCamera.xcodeproj/project.pbxproj" \
+  "$ROOT_DIR/Makefile" \
+  "$ROOT_DIR/docs/plans/2026-06-17-foursquare-venue-distance-boundary.md" <<'PY'
+import sys
+from pathlib import Path
+
+view = Path(sys.argv[1]).read_text()
+policy = Path(sys.argv[2]).read_text()
+tests = Path(sys.argv[3]).read_text()
+project = Path(sys.argv[4]).read_text()
+makefile = Path(sys.argv[5]).read_text()
+plan = " ".join(Path(sys.argv[6]).read_text().split())
+
+required_policy = (
+    "Double(Int.max).nextDown",
+    "maximumConvertibleMeters",
+    "distance.isFinite",
+    "distance >= 0",
+    "distance <= maximumConvertibleMeters",
+    "return Int(distance * feetPerMeter)",
+)
+required_tests = (
+    'expect(0, feet: 0, "zero")',
+    'expect(200, feet: 656, "ordinary venue radius")',
+    "maximumMeters.nextUp",
+    "Double.nan",
+    "Double.infinity",
+    "-Double.infinity",
+)
+required_plan = (
+    "Repository-root and external-directory `make check` passed",
+    "Eight isolated mutations were rejected",
+    "no live Foursquare request was made",
+    "historical Mapbox secret-scanning alert remains an external rotation or revocation boundary",
+)
+
+if any(item not in policy for item in required_policy):
+    raise SystemExit("Venue distance conversion must remain finite, nonnegative, and Int-bounded.")
+if "FoursquareVenueDistancePolicy.feet(" not in view or "let distanceFeet" not in view:
+    raise SystemExit("Venue rendering must delegate distance conversion to the production policy.")
+if any(item not in tests for item in required_tests):
+    raise SystemExit("Executable venue distance boundary cases must remain registered.")
+if project.count("FoursquareVenueDistancePolicy.swift in Sources") != 2 or project.count("/* FoursquareVenueDistancePolicy.swift */") != 3:
+    raise SystemExit("Venue distance policy must remain a member of the app target.")
+if "run-foursquare-venue-distance-tests.sh" not in makefile:
+    raise SystemExit("The canonical Make gate must execute the venue distance policy harness.")
+if "status: pending_hosted_verification" in plan:
+    plan_status_valid = "Exact-head hosted checks remain pending." in plan
+elif "status: completed" in plan:
+    plan_status_valid = "Both exact-head push and pull-request checks passed." in plan
+else:
+    plan_status_valid = False
+if not plan_status_valid or any(item not in plan for item in required_plan):
+    raise SystemExit("Venue distance plan must record completed verification and external secret boundary.")
+PY
+
+if ! grep -Fq 'integer-foot conversion is bounded' "$ROOT_DIR/README.md" || \
+  ! grep -Fq 'integer conversion must remain bounded' "$ROOT_DIR/SECURITY.md" || \
+  ! grep -Fq 'Bound venue distance conversion before integer rendering' "$ROOT_DIR/VISION.md" || \
+  ! grep -Fq 'Bound venue distance conversion before integer rendering' "$ROOT_DIR/CHANGES.md" || \
+  ! grep -Fq 'Keep venue distance-to-feet conversion within Int bounds' "$ROOT_DIR/AGENTS.md"; then
+  printf '%s\n' "Project guidance must preserve the venue distance conversion boundary." >&2
+  exit 1
+fi
 
 python3 - "$RESPONSE_REDIRECT_PLAN" <<'PY'
 import re

--- a/scripts/check-baseline.sh
+++ b/scripts/check-baseline.sh
@@ -987,8 +987,13 @@ required_tests = (
     "-Double.infinity",
 )
 required_plan = (
+    "status: completed",
     "Repository-root and external-directory `make check` passed",
     "Eight isolated mutations were rejected",
+    "Both exact-head push and pull-request checks passed",
+    "`0b540e158042063e06b4a7a822aee7d2b53497c3`",
+    "Push run `27673872489`",
+    "pull-request run `27673883985`",
     "no live Foursquare request was made",
     "historical Mapbox secret-scanning alert remains an external rotation or revocation boundary",
 )
@@ -1003,13 +1008,7 @@ if project.count("FoursquareVenueDistancePolicy.swift in Sources") != 2 or proje
     raise SystemExit("Venue distance policy must remain a member of the app target.")
 if "run-foursquare-venue-distance-tests.sh" not in makefile:
     raise SystemExit("The canonical Make gate must execute the venue distance policy harness.")
-if "status: pending_hosted_verification" in plan:
-    plan_status_valid = "Exact-head hosted checks remain pending." in plan
-elif "status: completed" in plan:
-    plan_status_valid = "Both exact-head push and pull-request checks passed." in plan
-else:
-    plan_status_valid = False
-if not plan_status_valid or any(item not in plan for item in required_plan):
+if any(item not in plan for item in required_plan):
     raise SystemExit("Venue distance plan must record completed verification and external secret boundary.")
 PY
 

--- a/scripts/run-foursquare-venue-distance-tests.sh
+++ b/scripts/run-foursquare-venue-distance-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+SWIFTC=${SWIFTC:-swiftc}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/foursquare-venue-distance-tests.XXXXXX")
+
+cleanup() {
+    rm -rf -- "$BUILD_DIR"
+}
+trap cleanup 0
+trap 'exit 129' 1
+trap 'exit 130' 2
+trap 'exit 143' 15
+
+"$SWIFTC" \
+    "$ROOT/FoursquareARCamera/Source/FoursquareVenueDistancePolicy.swift" \
+    "$ROOT/Tests/FoursquareVenueDistancePolicyTests/main.swift" \
+    -o "$BUILD_DIR/foursquare-venue-distance-tests"
+
+"$BUILD_DIR/foursquare-venue-distance-tests"


### PR DESCRIPTION
## Summary

Malformed venue distances can no longer terminate the app during integer-foot conversion. The production parser skips values whose converted result cannot fit safely in `Int`, and the completed verification plan now retains immutable hosted proof.

## Baseline

Venue coordinates and distances were already required to be finite and nonnegative, but a very large finite distance could still trap at `Int(distance * 3.28084)`. After the implementation passed both canonical events, its plan incorrectly remained marked as pending and the checker allowed that stale state.

## Improvements

- Centralize safe meters-to-feet conversion in a Foundation-only production policy.
- Keep overflow on the existing malformed-venue skip path.
- Compile the same production helper into the app target and a standalone Swift behavioral harness.
- Require completed plan status, implementation head `0b540e158042063e06b4a7a822aee7d2b53497c3`, push run `27673872489`, and pull-request run `27673883985`.

## Validation

- Repository-root and external-directory `make check`
- Static production delegation, Xcode membership, Make/workflow wiring, and guidance contracts
- Eight implementation mutations and four evidence-contract mutations rejected
- Shell syntax, exact diff, artifact, conflict-marker, and credential-shaped addition audits
- Implementation head `0b540e158042063e06b4a7a822aee7d2b53497c3` passed both canonical hosted macOS runs
- Exact evidence head `1b66bae918fb57479067c94fbcb8bc331ce57f05` passed runs `27697284576` and `27697288073`
- Local Linux validation truthfully skipped Swift execution and Xcode parsing because `swiftc` and `xcodebuild` are unavailable; hosted macOS supplied executable confirmation

## Risk

The policy prevents integer conversion traps without inventing a tighter provider-specific distance limit. No live Foursquare request was made. Historical Mapbox secret alert #1 remains a provider-side rotation or revocation boundary; no secret value was read or recorded.

A Swift policy harness failure, Xcode project-parse failure, or credential baseline failure must block integration.

## Follow-Ups

- Rotate or revoke the historically exposed Mapbox credential through the provider; repository-only evidence cannot prove that action.
- Keep this PR stacked on PR #17 for base-first review; neither PR should be merged or closed without explicit authorization.
- Retain both exact-head checks as integration evidence; no deployed runtime monitoring is required.
